### PR TITLE
ci: chain RTD preview builds after GA lint passes (experiment)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,4 +36,4 @@ jobs:
           curl -fsSL -X POST \
             -H "Content-Type: application/json" \
             -d '{"token": "${{ secrets.RTD_TOKEN }}", "branches": ["${{ github.head_ref }}"]}' \
-            "https://readthedocs.org/api/v2/webhook/${{ vars.RTD_PROJECT_SLUG }}/${{ vars.RTD_WEBHOOK_ID }}/"
+            "${{ vars.RTD_WEBHOOK_URL }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,3 +25,15 @@ jobs:
 
       - name: Build Sphinx docs
         run: uv run sphinx-build -W --keep-going docs/src build/html
+
+  trigger-rtd:
+    if: github.event_name == 'pull_request'
+    needs: lint-and-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ReadTheDocs build
+        run: |
+          curl -fsSL -X POST \
+            -H "Content-Type: application/json" \
+            -d '{"token": "${{ secrets.RTD_TOKEN }}", "branches": ["${{ github.head_ref }}"]}' \
+            "https://readthedocs.org/api/v2/webhook/${{ vars.RTD_PROJECT_SLUG }}/${{ vars.RTD_WEBHOOK_ID }}/"


### PR DESCRIPTION
## Summary

- Adds a `trigger-rtd` job to the GitHub Actions `Docs` workflow
- This job runs **only on pull_request events**, **after** `lint-and-build` passes
- It calls the RTD generic incoming webhook API to trigger a docs preview build for the PR branch

## Purpose

Test the chained CI approach: GA lint/format first → RTD build second. This avoids wasting RTD build minutes on PRs that fail lint.

**Important**: RTD "Build pull requests" is currently turned off. This PR tests whether triggering the generic webhook with a PR branch name creates a `pr-N` preview version. If not, we may need to re-enable RTD PR builds and rely solely on the GA gate for quality.

## What does NOT change

- `main` branch RTD builds are unaffected — they use the existing GitHub→RTD push webhook
- The `lint-and-build` job is unchanged