### PR TITLE
HPC4 quick start draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ cython_debug/
 
 # Ruff stuff:
 .ruff_cache/
+.codegraph/

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -42,6 +42,8 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx.ext.graphviz",
+    "sphinxcontrib.mermaid",
 ]
 
 intersphinx_mapping = {

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -15,6 +15,7 @@ find some useful techniques in general and works on other HPC systems as well.
     :maxdepth: 2
     :caption: Sections
 
+    quick-start/index
     software/index
     compile-guides/index
     sysadmin/index

--- a/docs/src/quick-start/access-and-authentication.rst
+++ b/docs/src/quick-start/access-and-authentication.rst
@@ -26,9 +26,7 @@ Account Application
 
 - Available to HKUST researchers.
 - Details about your initial credentials are provided in your HPC welcome
-  email.  See the `HPC Account Email Generator
-  <https://github.com/hkust-hpc-team/hpc-account-email-generator>`__
-  for the template used to generate that email.
+  email — keep it handy as you follow this guide.
 - Account applications are available to HKUST faculty members acting as principal investigators (PIs) for their research projects.
 - Users must apply for an account before accessing the HPC4 cluster.
 - All applications must be sponsored by a principal investigator (PI), who must be a faculty member of the university.

--- a/docs/src/quick-start/access-and-authentication.rst
+++ b/docs/src/quick-start/access-and-authentication.rst
@@ -9,6 +9,11 @@ Access and Authentication
 
     | Last updated: 2026-06-04
 
+.. tip::
+
+   If you are new to HPC clusters, read the :ref:`Understanding the Cluster
+   <understanding-the-cluster>` section first.
+
 Environment
 -----------
 
@@ -20,6 +25,10 @@ Account Application
 ~~~~~~~~~~~~~~~~~~~
 
 - Available to HKUST researchers.
+- Details about your initial credentials are provided in your HPC welcome
+  email.  See the `HPC Account Email Generator
+  <https://github.com/hkust-hpc-team/hpc-account-email-generator>`__
+  for the template used to generate that email.
 - Account applications are available to HKUST faculty members acting as principal investigators (PIs) for their research projects.
 - Users must apply for an account before accessing the HPC4 cluster.
 - All applications must be sponsored by a principal investigator (PI), who must be a faculty member of the university.

--- a/docs/src/quick-start/access-and-authentication.rst
+++ b/docs/src/quick-start/access-and-authentication.rst
@@ -2,8 +2,8 @@ Access and Authentication
 =========================
 
 .. meta::
-    :description: Access requirements and SSH login workflow for first-time HPC4 users.
-    :keywords: HPC4, access, authentication, SSH, Duo MFA, VPN
+    :description: Access requirements and SSH login workflow for new HPC4 and SuperPOD users.
+    :keywords: HPC4, SuperPOD, access, authentication, SSH, Duo MFA, VPN, account application
 
 .. rst-class:: header
 
@@ -17,40 +17,66 @@ Access and Authentication
 Environment
 -----------
 
-    - Users who need to access the HPC service for the first time
+    - Users who need to access HPC4 or SuperPOD for the first time
     - Windows 10/11, macOS, or Linux
     - SSH client or other approved remote access tools
 
 Account Application
 ~~~~~~~~~~~~~~~~~~~
 
-- Available to HKUST researchers.
-- Details about your initial credentials are provided in your HPC welcome
-  email — keep it handy as you follow this guide.
-- Account applications are available to HKUST faculty members acting as principal investigators (PIs) for their research projects.
-- Users must apply for an account before accessing the HPC4 cluster.
-- All applications must be sponsored by a principal investigator (PI), who must be a faculty member of the university.
-- A PI must also apply for an account if they need direct access to the cluster.
-- The HPC4 account name is the same as the user's HKUST account name.
-- The HPC4 account password is the same as the user's HKUST account password.
+Both HPC4 and SuperPOD accounts are available to HKUST researchers.
+Applications must be sponsored by a principal investigator (PI), who must
+be a HKUST faculty member.  Account names and passwords are the same as
+your HKUST credentials.
+
+- **HPC4**: `Account Application Form <https://hkust.service-now.com/itsc?id=sc_cat_item&sys_id=ae106bca47901a50a0c3db74116d4358>`__
+- **SuperPOD**: `Account Application Form <https://hkust.service-now.com/itsc?id=sc_cat_item&sys_id=828f67fc4704d610b0c2b9ca216d433e>`__
+
+Students should ask their supervisor (PI) to submit the application on
+their behalf.  A PI must also apply for an account if they need direct
+access.
+
+.. note::
+
+   **For teaching / courses**: if you need HPC resources for an
+   instructor-led course, contact ``cchelp@ust.hk`` and specify your
+   course code and computing resource requirements.
 
 Login Methods
 ~~~~~~~~~~~~~
 
-- HPC4 SSH login supports both password authentication and public-key authentication.
-- For password authentication, Duo MFA is required as a second factor.
-- Users should enroll in Duo MFA before attempting password-based SSH login.
-- For login, enter your username only, without the ``@ust.hk`` or ``@connect.ust.hk`` domain name.
+Both clusters support password and public-key SSH authentication.
+Password authentication requires Duo MFA as a second factor —
+enroll in Duo MFA beforehand.
+
+When logging in, enter your **username only** — do not include
+``@ust.hk`` or ``@connect.ust.hk``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 37 38
+
+   * -
+     - HPC4
+     - SuperPOD
+   * - Hostname
+     - ``hpc4.ust.hk``
+     - ``superpod.ust.hk``
+   * - SSH port
+     - 22 (default)
+     - 22 (default)
+   * - Authentication
+     - Password + Duo MFA, or public key
+     - Password + Duo MFA, or public key
+   * - Account credentials
+     - Your HKUST ITSC account
+     - Your HKUST ITSC account
+   * - Example SSH command
+     - ``ssh alice@hpc4.ust.hk``
+     - ``ssh alice@superpod.ust.hk``
 
 SSH with password and Duo authentication
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use any SSH client to log in to ``hpc4.ust.hk``.
-
-When logging in from a terminal:
-
-- Enter your HKUST username only.
-- Do not include ``@ust.hk`` or ``@connect.ust.hk`` in the username.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: shell-session
 
@@ -59,18 +85,115 @@ When logging in from a terminal:
     Duo two-factor login for <username>
     Enter a passcode or select one of your enrolled Duo authentication methods.
 
-After entering your password, complete the Duo authentication step using one of your enrolled Duo methods.
+After entering your password, complete the Duo authentication step.
+
+SSH with public key (recommended for daily use)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An SSH key pair eliminates the password + Duo MFA prompt on every login.
+Use this if you log in frequently.
+
+.. dropdown:: Linux / macOS
+   :class-title: sd-fs-5
+   :animate: fade-in
+
+   **Step 1 — Generate a key pair (on your local machine):**
+
+   .. code-block:: bash
+
+       ssh-keygen -t ed25519 -C "your_username@hkust"
+
+   Accept the defaults (file ``~/.ssh/id_ed25519``, no passphrase is ok for
+   personal workstations; use a passphrase if shared or public machine).
+
+   **Step 2 — Copy the public key to the cluster:**
+
+   .. code-block:: bash
+
+       ssh-copy-id <username>@hpc4.ust.hk
+
+   Enter your password once.  This installs ``~/.ssh/id_ed25519.pub`` into
+   ``~/.ssh/authorized_keys`` on the cluster.
+
+   **Step 3 — Test:**
+
+   .. code-block:: bash
+
+       ssh <username>@hpc4.ust.hk
+
+   You should log in without a password prompt.
+
+   **Repeat for SuperPOD** — the same key works for both clusters:
+
+   .. code-block:: bash
+
+       ssh-copy-id <username>@superpod.ust.hk
+
+.. dropdown:: Windows (PowerShell)
+   :class-title: sd-fs-5
+   :animate: fade-in
+
+   Windows 10/11 ships with OpenSSH.  Open **PowerShell** (not CMD) and
+   run the same commands as Linux:
+
+   **Step 1 — Generate a key pair:**
+
+   .. code-block:: powershell
+
+       ssh-keygen -t ed25519 -C "your_username@hkust"
+
+   **Step 2 — Copy the public key to the cluster:**
+
+   ``ssh-copy-id`` is not available on Windows.  Use this one-liner instead:
+
+   .. code-block:: powershell
+
+       Get-Content ~\.ssh\id_ed25519.pub | ssh <username>@hpc4.ust.hk "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys"
+
+   **Step 3 — Test:**
+
+   .. code-block:: powershell
+
+       ssh <username>@hpc4.ust.hk
+
+   **Repeat for SuperPOD**:
+
+   .. code-block:: powershell
+
+       Get-Content ~\.ssh\id_ed25519.pub | ssh <username>@superpod.ust.hk "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys"
+
+When to use which
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * -
+     - Password + Duo MFA
+     - SSH public key
+   * - Security
+     - Good — MFA adds second factor
+     - Good — passphrase on key adds second factor
+   * - Convenience
+     - Must enter password + Duo every time
+     - No prompt after initial setup
+   * - Best for
+     - First-time login, infrequent access
+     - Daily work, automation, rsync
 
 VPN Requirements
 ~~~~~~~~~~~~~~~~
 
-- Before using HPC4, connect to the campus network using either a wired campus connection or the ``eduroam`` Wi-Fi service.
-- If you are off campus, use Secure Remote Access (VPN) before connecting to HPC4.
-- Off-campus users should not assume direct access to ``hpc4.ust.hk`` without VPN.
+- Connect to the campus network via wired connection or ``eduroam`` Wi-Fi.
+- If you are off campus, use `Secure Remote Access VPN
+  <https://itso.hkust.edu.hk/services/cyber-security/vpn>`__ before
+  connecting.
 
 References
 ----------
 
-- Official VPN setup page: https://itso.hkust.edu.hk/services/cyber-security/vpn
-- Official login guide: https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4/login
-- Official Duo MFA page: https://itso.hkust.edu.hk/services/cyber-security/duo
+- `HPC4 login guide <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4/login>`__
+- `SuperPOD login guide <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod/usage-tips/login>`__
+- `VPN setup <https://itso.hkust.edu.hk/services/cyber-security/vpn>`__
+- `Duo MFA <https://itso.hkust.edu.hk/services/cyber-security/duo>`__

--- a/docs/src/quick-start/access-and-authentication.rst
+++ b/docs/src/quick-start/access-and-authentication.rst
@@ -1,0 +1,61 @@
+Access and Authentication
+=========================
+
+Environment
+-----------
+
+    - Users who need to access the HPC service for the first time
+    - Windows 10/11, macOS, or Linux
+    - SSH client or other approved remote access tools
+
+Account Application
+~~~~~~~~~~~~~~~~~~~
+
+- Available to HKUST researchers.
+- Account applications are available to HKUST faculty members acting as principal investigators (PIs) for their research projects.
+- Users must apply for an account before accessing the HPC4 cluster.
+- All applications must be sponsored by a principal investigator (PI), who must be a faculty member of the university.
+- A PI must also apply for an account if they need direct access to the cluster.
+- The HPC4 account name is the same as the user's HKUST account name.
+- The HPC4 account password is the same as the user's HKUST account password.
+
+Login Methods
+~~~~~~~~~~~~~
+
+- HPC4 SSH login supports both password authentication and public-key authentication.
+- For password authentication, Duo MFA is required as a second factor.
+- Users should enroll in Duo MFA before attempting password-based SSH login.
+- For login, enter your username only, without the ``@ust.hk`` or ``@connect.ust.hk`` domain name.
+
+SSH with password and Duo authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use any SSH client to log in to ``hpc4.ust.hk``.
+
+When logging in from a terminal:
+
+- Enter your HKUST username only.
+- Do not include ``@ust.hk`` or ``@connect.ust.hk`` in the username.
+
+.. code-block:: shell-session
+
+    $ ssh <username>@hpc4.ust.hk
+    <username>@hpc4.ust.hk's password:
+    Duo two-factor login for <username>
+    Enter a passcode or select one of your enrolled Duo authentication methods.
+
+After entering your password, complete the Duo authentication step using one of your enrolled Duo methods.
+
+VPN Requirements
+~~~~~~~~~~~~~~~~
+
+- Before using HPC4, connect to the campus network using either a wired campus connection or the ``eduroam`` Wi-Fi service.
+- If you are off campus, use Secure Remote Access (VPN) before connecting to HPC4.
+- Off-campus users should not assume direct access to ``hpc4.ust.hk`` without VPN.
+
+References
+----------
+
+- Official VPN setup page: https://itso.hkust.edu.hk/services/cyber-security/vpn
+- Official login guide: https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4/login
+- Official Duo MFA page: https://itso.hkust.edu.hk/services/cyber-security/duo

--- a/docs/src/quick-start/access-and-authentication.rst
+++ b/docs/src/quick-start/access-and-authentication.rst
@@ -1,6 +1,14 @@
 Access and Authentication
 =========================
 
+.. meta::
+    :description: Access requirements and SSH login workflow for first-time HPC4 users.
+    :keywords: HPC4, access, authentication, SSH, Duo MFA, VPN
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 Environment
 -----------
 

--- a/docs/src/quick-start/cluster-architecture.svg
+++ b/docs/src/quick-start/cluster-architecture.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 620" font-family="Arial, Helvetica, sans-serif">
+  <rect width="820" height="620" fill="#fff"/>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="7" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+    </marker>
+  </defs>
+
+  <!-- Your Machine -->
+  <rect x="260" y="15" width="300" height="55" rx="8" fill="#e8f0fe" stroke="#4285f4" stroke-width="2"/>
+  <text x="410" y="40" text-anchor="middle" font-size="17" font-weight="700" fill="#1a56db">Your Machine</text>
+  <text x="410" y="58" text-anchor="middle" font-size="12" fill="#444">SSH client (terminal)</text>
+
+  <!-- Branch from Your Machine to two clusters -->
+  <line x1="410" y1="70" x2="410" y2="90" stroke="#555" stroke-width="2"/>
+  <line x1="180" y1="90" x2="640" y2="90" stroke="#555" stroke-width="2"/>
+  <line x1="180" y1="90" x2="180" y2="110" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="640" y1="90" x2="640" y2="110" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- ==================== HPC4 (left) ==================== -->
+  <rect x="20" y="108" width="330" height="490" rx="10" fill="#f9fbff" stroke="#4285f4" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="185" y="130" text-anchor="middle" font-size="15" font-weight="700" fill="#1a56db">HPC4 Cluster</text>
+  <text x="185" y="147" text-anchor="middle" font-size="11" fill="#555">hpc4.ust.hk</text>
+
+  <!-- HPC4 Login -->
+  <rect x="55" y="158" width="260" height="60" rx="8" fill="#fff3e0" stroke="#f57c00" stroke-width="2"/>
+  <text x="185" y="183" text-anchor="middle" font-size="15" font-weight="700" fill="#e65100">Login Nodes</text>
+  <text x="185" y="200" text-anchor="middle" font-size="11" fill="#555">edit files · submit jobs · transfer data</text>
+  <rect x="100" y="204" width="170" height="14" rx="7" fill="#ffd54f"/>
+  <text x="185" y="214" text-anchor="middle" font-size="10" font-weight="700" fill="#6d4c00">No heavy computation</text>
+
+  <!-- HPC4 arrow -->
+  <line x1="185" y1="218" x2="185" y2="240" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- HPC4 Slurm -->
+  <rect x="55" y="242" width="260" height="50" rx="8" fill="#fce4ec" stroke="#c62828" stroke-width="2"/>
+  <text x="185" y="265" text-anchor="middle" font-size="15" font-weight="700" fill="#b71c1c">Slurm Scheduler</text>
+  <text x="185" y="282" text-anchor="middle" font-size="11" fill="#555">queue · priority · allocation</text>
+
+  <!-- HPC4 branch to compute -->
+  <line x1="185" y1="292" x2="185" y2="315" stroke="#555" stroke-width="2"/>
+  <line x1="85" y1="315" x2="285" y2="315" stroke="#555" stroke-width="2"/>
+  <line x1="85" y1="315" x2="85" y2="335" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="285" y1="315" x2="285" y2="335" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- HPC4 CPU compute -->
+  <rect x="30" y="337" width="110" height="65" rx="8" fill="#e8f5e9" stroke="#388e3c" stroke-width="2"/>
+  <text x="85" y="360" text-anchor="middle" font-size="14" font-weight="700" fill="#1b5e20">CPU Nodes</text>
+  <text x="85" y="376" text-anchor="middle" font-size="11" fill="#444">amd / intel</text>
+  <text x="85" y="392" text-anchor="middle" font-size="10" fill="#666">partitions: amd, intel</text>
+
+  <!-- HPC4 GPU compute -->
+  <rect x="230" y="337" width="110" height="65" rx="8" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2"/>
+  <text x="285" y="360" text-anchor="middle" font-size="14" font-weight="700" fill="#4a148c">GPU Nodes</text>
+  <text x="285" y="376" text-anchor="middle" font-size="11" fill="#444">A30 / L20 / RTX</text>
+  <text x="285" y="392" text-anchor="middle" font-size="10" fill="#666">partitions: gpu-*</text>
+
+  <!-- HPC4 Storage -->
+  <rect x="30" y="420" width="310" height="75" rx="8" fill="#f8f9fa" stroke="#90a4ae" stroke-width="1.5"/>
+  <text x="185" y="442" text-anchor="middle" font-size="13" font-weight="700" fill="#455a64">Shared Storage</text>
+  <rect x="42" y="452" width="138" height="32" rx="5" fill="#fff8e1" stroke="#f9a825" stroke-width="1"/>
+  <text x="111" y="465" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">/scratch</text>
+  <text x="111" y="478" text-anchor="middle" font-size="10" fill="#555">500 GB · 60-day purge</text>
+  <rect x="190" y="452" width="138" height="32" rx="5" fill="#e8eaf6" stroke="#3949ab" stroke-width="1"/>
+  <text x="259" y="465" text-anchor="middle" font-size="12" font-weight="700" fill="#1a237e">/home /project</text>
+  <text x="259" y="478" text-anchor="middle" font-size="10" fill="#555">200 GB / 10 TB</text>
+
+  <!-- HPC4 dashed lines for storage -->
+  <line x1="85" y1="402" x2="85" y2="420" stroke="#4285f4" stroke-dasharray="4,3"/>
+  <line x1="285" y1="402" x2="285" y2="420" stroke="#4285f4" stroke-dasharray="4,3"/>
+
+  <!-- HPC4 note -->
+  <text x="185" y="516" text-anchor="middle" font-size="11" fill="#1565c0" font-style="italic">storage accessible from login + compute nodes</text>
+
+  <!-- ==================== SuperPOD (right) ==================== -->
+  <rect x="470" y="108" width="330" height="490" rx="10" fill="#fffbf5" stroke="#f57c00" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="635" y="130" text-anchor="middle" font-size="15" font-weight="700" fill="#e65100">SuperPOD Cluster</text>
+  <text x="635" y="147" text-anchor="middle" font-size="11" fill="#555">superpod.ust.hk</text>
+
+  <!-- SuperPOD Login -->
+  <rect x="505" y="158" width="260" height="60" rx="8" fill="#fff3e0" stroke="#f57c00" stroke-width="2"/>
+  <text x="635" y="183" text-anchor="middle" font-size="15" font-weight="700" fill="#e65100">Login Nodes</text>
+  <text x="635" y="200" text-anchor="middle" font-size="11" fill="#555">edit files · submit jobs · transfer data</text>
+  <rect x="550" y="204" width="170" height="14" rx="7" fill="#ffd54f"/>
+  <text x="635" y="214" text-anchor="middle" font-size="10" font-weight="700" fill="#6d4c00">No heavy computation</text>
+
+  <!-- SuperPOD arrow -->
+  <line x1="635" y1="218" x2="635" y2="240" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- SuperPOD Slurm -->
+  <rect x="505" y="242" width="260" height="50" rx="8" fill="#fce4ec" stroke="#c62828" stroke-width="2"/>
+  <text x="635" y="265" text-anchor="middle" font-size="15" font-weight="700" fill="#b71c1c">Slurm Scheduler</text>
+  <text x="635" y="282" text-anchor="middle" font-size="11" fill="#555">queue · priority · allocation</text>
+
+  <!-- SuperPOD branch to compute -->
+  <line x1="635" y1="292" x2="635" y2="315" stroke="#555" stroke-width="2"/>
+  <line x1="535" y1="315" x2="735" y2="315" stroke="#555" stroke-width="2"/>
+  <line x1="535" y1="315" x2="535" y2="335" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="735" y1="315" x2="735" y2="335" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- SuperPOD CPU compute -->
+  <rect x="480" y="337" width="110" height="65" rx="8" fill="#e8f5e9" stroke="#388e3c" stroke-width="2"/>
+  <text x="535" y="360" text-anchor="middle" font-size="14" font-weight="700" fill="#1b5e20">CPU Nodes</text>
+  <text x="535" y="376" text-anchor="middle" font-size="11" fill="#444">preprocessing</text>
+  <text x="535" y="392" text-anchor="middle" font-size="10" fill="#666">partition: cpu</text>
+
+  <!-- SuperPOD GPU compute -->
+  <rect x="680" y="337" width="110" height="65" rx="8" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2"/>
+  <text x="735" y="360" text-anchor="middle" font-size="14" font-weight="700" fill="#4a148c">GPU Nodes</text>
+  <text x="735" y="376" text-anchor="middle" font-size="11" fill="#444">H800</text>
+  <text x="735" y="392" text-anchor="middle" font-size="10" fill="#666">partition: normal</text>
+
+  <!-- SuperPOD Storage -->
+  <rect x="480" y="420" width="310" height="75" rx="8" fill="#f8f9fa" stroke="#90a4ae" stroke-width="1.5"/>
+  <text x="635" y="442" text-anchor="middle" font-size="13" font-weight="700" fill="#455a64">Shared Storage</text>
+  <rect x="492" y="452" width="138" height="32" rx="5" fill="#fff8e1" stroke="#f9a825" stroke-width="1"/>
+  <text x="561" y="465" text-anchor="middle" font-size="12" font-weight="700" fill="#e65100">/scratch</text>
+  <text x="561" y="478" text-anchor="middle" font-size="10" fill="#555">5 TB/group · 30-day purge</text>
+  <rect x="640" y="452" width="138" height="32" rx="5" fill="#e8eaf6" stroke="#3949ab" stroke-width="1"/>
+  <text x="709" y="465" text-anchor="middle" font-size="12" font-weight="700" fill="#1a237e">/home /project</text>
+  <text x="709" y="478" text-anchor="middle" font-size="10" fill="#555">persistent</text>
+
+  <!-- SuperPOD dashed lines for storage -->
+  <line x1="535" y1="402" x2="535" y2="420" stroke="#4285f4" stroke-dasharray="4,3"/>
+  <line x1="735" y1="402" x2="735" y2="420" stroke="#4285f4" stroke-dasharray="4,3"/>
+
+  <!-- SuperPOD note -->
+  <text x="635" y="516" text-anchor="middle" font-size="11" fill="#1565c0" font-style="italic">storage accessible from login + compute nodes</text>
+
+  <!-- Separator label -->
+  <line x1="410" y1="108" x2="410" y2="600" stroke="#bbb" stroke-width="1" stroke-dasharray="8,4"/>
+  <text x="410" y="610" text-anchor="middle" font-size="11" fill="#888">separate clusters · separate logins · separate schedulers</text>
+</svg>

--- a/docs/src/quick-start/data-and-storage.rst
+++ b/docs/src/quick-start/data-and-storage.rst
@@ -1,6 +1,14 @@
 Data and Storage Guide
 ======================
 
+.. meta::
+    :description: Quick-start guide to choosing storage locations and transferring files to and from HPC4.
+    :keywords: HPC4, storage, data transfer, home, scratch, project, scp, sftp, rsync
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 This page helps new users decide where to place files on HPC4 and how to transfer files to and from the system.
 
 Environment

--- a/docs/src/quick-start/data-and-storage.rst
+++ b/docs/src/quick-start/data-and-storage.rst
@@ -1,0 +1,160 @@
+Data and Storage Guide
+======================
+
+This page helps new users decide where to place files on HPC4 and how to transfer files to and from the system.
+
+Environment
+-----------
+
+    - Users who have already obtained HPC4 access
+    - Windows 10/11, macOS, or Linux
+    - SSH client or file transfer tool with SSH support
+
+Directory Differentiation
+-------------------------
+
+Before uploading or generating files on HPC4, identify the correct destination directory.
+
+- ``/home/<username>``: Personal home directory for configuration files, small scripts, executables, container images, Conda environments, and small datasets. Default quota is 200 GB. Official HPC4 storage summary states that home directories have a 14-day backup window.
+- ``/scratch/<username>``: Per-user high-speed scratch space for temporary job input, intermediate files, and short-term job output. Default quota is 500 GB. Scratch is not backed up, and files without read or write access for 60 days are automatically purged.
+- ``/project/<groupname>``: Shared group storage for members of a PI research group. Default quota is 10 TB per research group. Use this for shared datasets, shared source code, and shared software packages.
+
+.. note::
+
+    Do not assume all directories have the same quota, retention policy, or backup policy.
+    On the official HPC4 storage page, home storage is backed up, while project and scratch storage are not.
+
+Recommended placement
+~~~~~~~~~~~~~~~~~~~~~
+
+- Put login scripts, dotfiles, small source trees, and personal Python environments in ``/home/<username>``.
+- Put large temporary datasets, intermediate results, and short-term job output in ``/scratch/<username>``.
+- Put shared project data, shared code, and shared software stacks in ``/project/<groupname>``.
+- Do not rely on ``/scratch/<username>`` for long-term retention.
+
+Useful capacity check
+~~~~~~~~~~~~~~~~~~~~~
+
+The official HPC4 storage page recommends this command to inspect the three major storage types:
+
+.. code-block:: bash
+
+     df -h /home /project /scratch
+
+File Transfer
+-------------
+
+HPC4 file transfer is typically done over SSH-based tools.
+
+The examples below were tested with a user home directory on 2026-06-04.
+They are suitable as smoke tests before you start transferring project data.
+
+Use the same HPC4 login hostname and username format as your SSH login:
+
+- use your HKUST username only
+- do not append ``@ust.hk`` or ``@connect.ust.hk`` to the username
+- if you are off campus, connect through VPN before starting file transfer
+
+SCP Example
+~~~~~~~~~~~
+
+Upload a local file to your home directory on HPC4:
+
+.. code-block:: bash
+
+    scp local-file.txt <username>@hpc4.ust.hk:~/
+
+Download the same file back to your local machine:
+
+.. code-block:: bash
+
+    scp <username>@hpc4.ust.hk:~/local-file.txt ./downloaded-file.txt
+
+SFTP Example
+~~~~~~~~~~~~
+
+Open an interactive SFTP session:
+
+.. code-block:: bash
+
+    sftp <username>@hpc4.ust.hk
+
+Example SFTP commands:
+
+.. code-block:: text
+
+    pwd
+    ls
+    put local-file.txt
+    get local-file.txt downloaded-via-sftp.txt
+    bye
+
+Rsync Example
+~~~~~~~~~~~~~
+
+Use ``rsync`` when transferring directories or repeatedly syncing updated files.
+
+Create a small local test directory first:
+
+.. code-block:: bash
+
+    mkdir -p local-folder
+    echo "rsync test" > local-folder/test.txt
+
+Preview the transfer without copying files:
+
+.. code-block:: bash
+
+    rsync -avn local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
+
+Run the actual transfer:
+
+.. code-block:: bash
+
+    rsync -av local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
+
+For real project use after the smoke test:
+
+- upload small personal scripts to ``/home/<username>``
+- upload large temporary job input and output under ``/scratch/<username>``
+- upload team-shared files under ``/project/<groupname>``
+
+Verify the Transfer
+-------------------
+
+After uploading or syncing files, verify that they exist on HPC4.
+
+For SCP upload verification:
+
+.. code-block:: bash
+
+    ssh <username>@hpc4.ust.hk 'ls -l ~/local-file.txt'
+
+For SCP download verification:
+
+.. code-block:: bash
+
+    cat downloaded-file.txt
+
+For rsync verification:
+
+.. code-block:: bash
+
+    ssh <username>@hpc4.ust.hk 'ls -R ~/rsync-test'
+    ssh <username>@hpc4.ust.hk 'cat ~/rsync-test/test.txt'
+
+Transfer Checklist
+------------------
+
+- Confirm the target directory before uploading.
+- Avoid writing large temporary files into the wrong location.
+- Verify that the transfer completed successfully before starting a job.
+- Use ``rsync`` instead of repeated manual copies when updating many files.
+- Remember that ``/scratch/<username>`` is automatically purged after inactivity and is not a backup location.
+
+References
+----------
+
+- Official login guide: https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4/login
+- Official VPN setup page: https://itso.hkust.edu.hk/services/cyber-security/vpn
+- Official storage types page: https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4/fileandstorage

--- a/docs/src/quick-start/data-and-storage.rst
+++ b/docs/src/quick-start/data-and-storage.rst
@@ -2,80 +2,123 @@ Data and Storage Guide
 ======================
 
 .. meta::
-    :description: Quick-start guide to choosing storage locations and transferring files to and from HPC4.
-    :keywords: HPC4, storage, data transfer, home, scratch, project, scp, sftp, rsync
+    :description: Quick-start guide to choosing storage locations and transferring files on HPC4 and SuperPOD.
+    :keywords: HPC4, SuperPOD, storage, data transfer, home, scratch, project, scp, sftp, rsync
 
 .. rst-class:: header
 
     | Last updated: 2026-06-04
 
-This page helps new users decide where to place files on HPC4 and how to transfer files to and from the system.
+This page helps new users decide where to place files on HPC4 or SuperPOD and how to transfer files to and from the system.
 
 Environment
 -----------
 
-    - Users who have already obtained HPC4 access
+    - Users who have already obtained HPC4 or SuperPOD access
     - Windows 10/11, macOS, or Linux
     - SSH client or file transfer tool with SSH support
 
-Directory Differentiation
--------------------------
+Directory Structure
+-------------------
 
-Before uploading or generating files on HPC4, identify the correct destination directory.
+Both HPC4 and SuperPOD provide three main storage tiers.
+The directory layout is similar, but quotas and retention policies differ.
 
-- ``/home/<username>``: Personal home directory for configuration files, small scripts, executables, container images, Conda environments, and small datasets. Default quota is 200 GB. Official HPC4 storage summary states that home directories have a 14-day backup window.
-- ``/scratch/<username>``: Per-user high-speed scratch space for temporary job input, intermediate files, and short-term job output. Default quota is 500 GB. Scratch is not backed up, and files without read or write access for 60 days are automatically purged.
-- ``/project/<groupname>``: Shared group storage for members of a PI research group. Default quota is 10 TB per research group. Use this for shared datasets, shared source code, and shared software packages.
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - Path
+     - HPC4
+     - SuperPOD
+   * - ``/home/<username>``
+     - 200 GB quota · backed up (14-day window)
+     - persistent · see welcome email
+   * - ``/scratch/<username>``
+     - 500 GB quota · auto-purged after 60 days of inactivity
+     - ``/scratch/<groupname>`` · 5 TB group quota · auto-purged after 30 days
+   * - ``/project/<groupname>``
+     - 10 TB per research group · not backed up
+     - shared group storage · see welcome email
 
 .. note::
 
-    Do not assume all directories have the same quota, retention policy, or backup policy.
-    On the official HPC4 storage page, home storage is backed up, while project and scratch storage are not.
+   ``/scratch`` is **temporary** high-speed storage.  Do not rely on it for
+   long-term retention.  Files without read or write access for the
+   retention period are automatically deleted.
 
-Recommended placement
+Recommended Placement
 ~~~~~~~~~~~~~~~~~~~~~
 
-- Put login scripts, dotfiles, small source trees, and personal Python environments in ``/home/<username>``.
-- Put large temporary datasets, intermediate results, and short-term job output in ``/scratch/<username>``.
-- Put shared project data, shared code, and shared software stacks in ``/project/<groupname>``.
-- Do not rely on ``/scratch/<username>`` for long-term retention.
+- **``/home/<username>``** — login scripts, dotfiles, small source trees, personal Python/Conda environments, container images.
+- **``/scratch/<username>``** (HPC4) or **``/scratch/<groupname>``** (SuperPOD) — large temporary datasets, intermediate results, short-term job output.
+- **``/project/<groupname>``** — shared datasets, shared source code, shared software stacks for your research group.
 
-Useful capacity check
-~~~~~~~~~~~~~~~~~~~~~
+Check Disk Usage
+~~~~~~~~~~~~~~~~
 
-The official HPC4 storage page recommends this command to inspect the three major storage types:
+Use ``df -h`` to inspect available space:
 
 .. code-block:: bash
 
-     df -h /home /project /scratch
+     df -h /home /scratch /project
 
 File Transfer
 -------------
 
-HPC4 file transfer is typically done over SSH-based tools.
-**File transfers should be initiated from the login node;**
-do not run ``rsync`` or ``scp`` from inside a compute job unless your
-workflow specifically requires it.
+**rsync is the recommended tool** for most file transfers.
+It supports directory sync, resume on failure, and delta transfers (only changed files).
 
-The examples below were tested with a user home directory on 2026-06-04.
-They are suitable as smoke tests before you start transferring project data.
+.. tip::
 
-Use the same HPC4 login hostname and username format as your SSH login:
+   Use ``rsync`` for all transfers.  It is more reliable than ``scp`` for
+   directories and large files, and it can resume interrupted transfers.
 
-- use your HKUST username only
-- do not append ``@ust.hk`` or ``@connect.ust.hk`` to the username
-- if you are off campus, connect through VPN before starting file transfer
+Use the same hostname and username format as your SSH login:
+
+- Use your HKUST username only (do not append ``@ust.hk``).
+- If you are off campus, connect through VPN before starting file transfer.
+
+Rsync Example (Recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Upload a local directory to your home directory on the cluster:
+
+.. code-block:: bash
+
+    rsync -av local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
+
+The ``-a`` flag preserves permissions and timestamps; ``-v`` shows progress.
+Add ``--progress`` for per-file transfer details.
+
+Download a directory from the cluster:
+
+.. code-block:: bash
+
+    rsync -av <username>@hpc4.ust.hk:~/rsync-test/ ./local-folder/
+
+Preview what would be transferred without copying:
+
+.. code-block:: bash
+
+    rsync -avn local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
+
+For real project use:
+
+- Upload small personal scripts to ``/home/<username>``
+- Upload large temporary job input and output under ``/scratch/<username>`` (HPC4) or ``/scratch/<groupname>`` (SuperPOD)
+- Upload team-shared files under ``/project/<groupname>``
 
 SCP Example
 ~~~~~~~~~~~
 
-Upload a local file to your home directory on HPC4:
+Upload a single file:
 
 .. code-block:: bash
 
     scp local-file.txt <username>@hpc4.ust.hk:~/
 
-Download the same file back to your local machine:
+Download a single file:
 
 .. code-block:: bash
 
@@ -100,52 +143,10 @@ Example SFTP commands:
     get local-file.txt downloaded-via-sftp.txt
     bye
 
-Rsync Example
-~~~~~~~~~~~~~
-
-Use ``rsync`` when transferring directories or repeatedly syncing updated files.
-
-Create a small local test directory first:
-
-.. code-block:: bash
-
-    mkdir -p local-folder
-    echo "rsync test" > local-folder/test.txt
-
-Preview the transfer without copying files:
-
-.. code-block:: bash
-
-    rsync -avn local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
-
-Run the actual transfer:
-
-.. code-block:: bash
-
-    rsync -av local-folder/ <username>@hpc4.ust.hk:~/rsync-test/
-
-For real project use after the smoke test:
-
-- upload small personal scripts to ``/home/<username>``
-- upload large temporary job input and output under ``/scratch/<username>``
-- upload team-shared files under ``/project/<groupname>``
-
 Verify the Transfer
 -------------------
 
-After uploading or syncing files, verify that they exist on HPC4.
-
-For SCP upload verification:
-
-.. code-block:: bash
-
-    ssh <username>@hpc4.ust.hk 'ls -l ~/local-file.txt'
-
-For SCP download verification:
-
-.. code-block:: bash
-
-    cat downloaded-file.txt
+After uploading or syncing files, verify that they exist on the cluster.
 
 For rsync verification:
 
@@ -154,14 +155,19 @@ For rsync verification:
     ssh <username>@hpc4.ust.hk 'ls -R ~/rsync-test'
     ssh <username>@hpc4.ust.hk 'cat ~/rsync-test/test.txt'
 
+For SCP verification:
+
+.. code-block:: bash
+
+    ssh <username>@hpc4.ust.hk 'ls -l ~/local-file.txt'
+
 Transfer Checklist
 ------------------
 
 - Confirm the target directory before uploading.
-- Avoid writing large temporary files into the wrong location.
+- Use ``rsync`` instead of repeated ``scp`` when updating many files.
 - Verify that the transfer completed successfully before starting a job.
-- Use ``rsync`` instead of repeated manual copies when updating many files.
-- Remember that ``/scratch/<username>`` is automatically purged after inactivity and is not a backup location.
+- Remember that ``/scratch`` is automatically purged after inactivity — it is not a backup location.
 
 References
 ----------

--- a/docs/src/quick-start/data-and-storage.rst
+++ b/docs/src/quick-start/data-and-storage.rst
@@ -53,6 +53,9 @@ File Transfer
 -------------
 
 HPC4 file transfer is typically done over SSH-based tools.
+**File transfers should be initiated from the login node;**
+do not run ``rsync`` or ``scp`` from inside a compute job unless your
+workflow specifically requires it.
 
 The examples below were tested with a user home directory on 2026-06-04.
 They are suitable as smoke tests before you start transferring project data.

--- a/docs/src/quick-start/first-job-template.rst
+++ b/docs/src/quick-start/first-job-template.rst
@@ -1,34 +1,51 @@
-Submit Your First HPC4 Job
+Submit Your First Job
 ==========================
 
 .. meta::
-    :description: Minimal first SLURM batch job walkthrough for HPC4 users who want one fast, successful CPU submission.
-    :keywords: HPC4, SLURM, sbatch, first job, quick start, batch job
+    :description: Minimal first SLURM batch job walkthrough for HPC4 and SuperPOD users who want one fast, successful CPU submission.
+    :keywords: HPC4, SuperPOD, SLURM, sbatch, first job, quick start, batch job
 
 .. rst-class:: header
 
     | Last updated: 2026-06-04
 
-This page is the shortest path to a first successful HPC4 batch job.
+This page is the shortest path to a first successful batch job on HPC4 or SuperPOD.
 It keeps the scope narrow: one small CPU script, one ``sbatch``, one output file.
+
+.. warning::
+
+   On **SuperPOD**, GPU partitions (``normal``) always allocate a full GPU node.
+   You cannot request CPU-only resources on these partitions.
+   For initial testing, use the ``cpu`` partition to avoid unnecessary GPU charges.
 
 Before You Start
 ----------------
 
-Make sure you can already log in to HPC4.
+Make sure you can already log in to the cluster (HPC4 or SuperPOD).
 Then confirm one valid SLURM account and CPU partition pair:
 
 .. code-block:: bash
 
-    sacctmgr show user <username> withassoc
+    sacctmgr show user $USER withassoc
+
+Example output (your account and partitions will differ):
+
+.. code-block:: text
+
+       User    Def Acct     Admin    Cluster    Account  Partition     Share   Priority  MaxJobs  MaxNodes  MaxCPUs  MaxSubmit  MaxWall  MaxCPUMins  QOS   Def QOS  GrpCPUs  GrpJobs  GrpNodes  GrpSubmit  GrpWall  GrpCPUMins
+    --------- ---------- --------- ---------- ---------- ---------- --------- --------- -------- --------- -------- ---------- -------- ---------- ----- -------- -------- -------- --------- ---------- -------- -----------
+       alice        itsc      None       hpc4        itsc        amd         1                                                      normal
+       alice        itsc      None       hpc4        itsc       intel        1                                                      normal
+       alice        itsc      None       hpc4        itsc     gpu-a30        1                                                      normal
 
 Use your own account and partition values from that output.
-One tested CPU combination on one account was ``--account=hpcintern`` with ``--partition=amd``.
+One tested CPU combination on one account was ``--account=itsc`` with ``--partition=amd``.
 
-.. important::
+.. warning::
 
-    Replace placeholders such as ``<username>``, ``<your-account>``, ``<your-partition>``, and ``<job_id>`` before running the commands.
-    If you type the angle brackets literally, the shell will treat them as redirection syntax and the command will fail.
+   If ``sbatch`` reports ``Invalid account or account/partition combination specified``,
+   re-check your ``#SBATCH --account`` and ``#SBATCH --partition`` pair against the
+   output of ``sacctmgr show user $USER withassoc``.
 
 Create the Smallest Useful Script
 ---------------------------------
@@ -61,17 +78,13 @@ Submit the script with:
 
     sbatch submit.sh
 
-If ``sbatch`` reports ``Invalid account or account/partition combination specified``, compare your ``#SBATCH --account`` and ``#SBATCH --partition`` settings with the output of ``sacctmgr show user <username> withassoc``.
-
 Expected output:
 
 .. code-block:: text
 
-    Submitted batch job <job_id>
+    Submitted batch job 1404973
 
-On one tested short CPU run, the command returned ``Submitted batch job 1404973``.
-
-Replace ``<job_id>`` below with the actual job ID returned by your submission.
+Replace ``1404973`` below with the actual job ID returned by your submission.
 
 Optional Quick Status Check
 ---------------------------
@@ -80,9 +93,9 @@ While the job is queued or running, check its status with:
 
 .. code-block:: bash
 
-    squeue -j <job_id>
+    squeue -j 1404973
 
-If the command returns ``Invalid job id``, the job may have already finished because the example job is very short.
+If the command returns only the header line, the job may have already finished because the example job is very short.
 
 Check the Output
 ----------------
@@ -97,14 +110,16 @@ Expected output:
 
 .. code-block:: text
 
-    Hello from cpu01
-
-On one tested short CPU run, the output file contained ``Hello from cpu13``.
+    Hello from cpu13
 
 Next Step
 ---------
 
 After this first CPU job works, move on to :doc:`job-submission` for GPU batch jobs, MPI batch jobs, interactive ``srun`` sessions, and ``squeue`` or ``scancel`` usage.
+
+For more complete SLURM templates, see the canonical example scripts:
+`HPC4 examples <https://github.com/hkust-hpc-team/hkust-hpc/tree/main/examples/hpc4-hello-world>`__
+(CPU, GPU, MPI, and interactive sessions).
 
 See Also
 --------

--- a/docs/src/quick-start/first-job-template.rst
+++ b/docs/src/quick-start/first-job-template.rst
@@ -12,12 +12,6 @@ Submit Your First HPC4 Job
 This page is the shortest path to a first successful HPC4 batch job.
 It keeps the scope narrow: one small CPU script, one ``sbatch``, one output file.
 
-.. toctree::
-    :maxdepth: 1
-    :titlesonly:
-
-    job-submission
-
 Before You Start
 ----------------
 

--- a/docs/src/quick-start/first-job-template.rst
+++ b/docs/src/quick-start/first-job-template.rst
@@ -1,0 +1,105 @@
+Submit Your First HPC4 Job
+==========================
+
+This page is the shortest path to a first successful HPC4 batch job.
+It keeps the scope narrow: one small CPU script, one ``sbatch``, one output file.
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    job-submission
+
+Before You Start
+----------------
+
+Make sure you can already log in to HPC4.
+Then confirm one valid SLURM account and CPU partition pair:
+
+.. code-block:: bash
+
+    sacctmgr show user <username> withassoc
+
+Use your own account and partition values from that output.
+One tested CPU combination on one account was ``--account=hpcintern`` with ``--partition=amd``.
+
+.. important::
+
+    Replace placeholders such as ``<username>``, ``<your-account>``, ``<your-partition>``, and ``<job_id>`` before running the commands.
+    If you type the angle brackets literally, the shell will treat them as redirection syntax and the command will fail.
+
+Create the Smallest Useful Script
+---------------------------------
+
+Create a file named ``submit.sh`` with the following content:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=quick-start
+    #SBATCH --output=quick-start.out
+    #SBATCH --open-mode=truncate
+    #SBATCH --time=00:05:00
+    #SBATCH --nodes=1
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=1
+    #SBATCH --account=<your-account>
+    #SBATCH --partition=<your-partition>
+
+    echo "Hello from $(hostname)"
+
+This script is intentionally minimal. It only proves that batch submission works and that the job can run on a compute node.
+
+Submit the Job
+--------------
+
+Submit the script with:
+
+.. code-block:: bash
+
+    sbatch submit.sh
+
+If ``sbatch`` reports ``Invalid account or account/partition combination specified``, compare your ``#SBATCH --account`` and ``#SBATCH --partition`` settings with the output of ``sacctmgr show user <username> withassoc``.
+
+Expected output:
+
+.. code-block:: text
+
+    Submitted batch job <job_id>
+
+On one tested short CPU run, the command returned ``Submitted batch job 1404973``.
+
+Replace ``<job_id>`` below with the actual job ID returned by your submission.
+
+Optional Quick Status Check
+---------------------------
+
+While the job is queued or running, check its status with:
+
+.. code-block:: bash
+
+    squeue -j <job_id>
+
+If the command returns ``Invalid job id``, the job may have already finished because the example job is very short.
+
+Check the Output
+----------------
+
+After the job completes, inspect the output file:
+
+.. code-block:: bash
+
+    cat quick-start.out
+
+Expected output:
+
+.. code-block:: text
+
+    Hello from cpu01
+
+On one tested short CPU run, the output file contained ``Hello from cpu13``.
+
+Next Step
+---------
+
+After this first CPU job works, move on to :doc:`job-submission` for GPU batch jobs, MPI batch jobs, interactive ``srun`` sessions, and ``squeue`` or ``scancel`` usage.

--- a/docs/src/quick-start/first-job-template.rst
+++ b/docs/src/quick-start/first-job-template.rst
@@ -1,6 +1,14 @@
 Submit Your First HPC4 Job
 ==========================
 
+.. meta::
+    :description: Minimal first SLURM batch job walkthrough for HPC4 users who want one fast, successful CPU submission.
+    :keywords: HPC4, SLURM, sbatch, first job, quick start, batch job
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 This page is the shortest path to a first successful HPC4 batch job.
 It keeps the scope narrow: one small CPU script, one ``sbatch``, one output file.
 
@@ -103,3 +111,9 @@ Next Step
 ---------
 
 After this first CPU job works, move on to :doc:`job-submission` for GPU batch jobs, MPI batch jobs, interactive ``srun`` sessions, and ``squeue`` or ``scancel`` usage.
+
+See Also
+--------
+
+- :doc:`/software/software-support-overview`
+- :doc:`How to Submit and Run Batch Jobs with SLURM </kb/slurm/slurm-how-to-submit-and-run-batch-jobs-G75o-i>`

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -13,6 +13,23 @@ Use this page as the main onboarding entry for new HPC4 users.
 If you received a welcome email with your initial credentials,
 keep that email handy as you follow this guide.
 
+.. note::
+
+   This quick-start covers **HPC4 only**.  If you are using
+   **SuperPOD** (``superpod.ust.hk``), the workflow differs:
+
+   - SuperPOD primarily uses **container-based environments**
+     (Enroot with Pyxis SLURM integration).  See :doc:`/kb/enroot/index`.
+   - The edge Spack instance is located at ``/scratch/spack/2025``
+     (not ``/opt/shared/.spack-edge``).
+   - Available partitions are ``normal``, ``preempt``, and ``cpu``.
+   - Interactive sessions have a maximum walltime of 2 hours
+     (4 hours on HPC4).
+
+   Check your welcome email and the
+   `SuperPOD website <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod>`__
+   for details.
+
 .. _understanding-the-cluster:
 
 Understanding the Cluster

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -1,13 +1,21 @@
 Quick Start
 ===========
 
+.. meta::
+    :description: Quick-start onboarding path for new HPC4 users covering access, storage, software setup, and first SLURM jobs.
+    :keywords: HPC4, quick start, onboarding, SLURM, software environment, storage
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 Use this page as the main onboarding entry for new HPC4 users.
 
 Background
 ----------
 
 HPC4 is designed for CPU-intensive computational jobs and jobs requiring GPU coprocessor support.
-It is open to all approved university researchers, while School of Science and Engineering users have higher access priority.
+It is open to approved university researchers.
 
 Use the pages below as the main onboarding path.
 Each item includes a short description so readers can decide where to start.

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -51,16 +51,21 @@ Slurm also enforces fair sharing: no single user can monopolise the cluster.
 Cluster vs your laptop
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. list-table::
-   :header-rows: 1
-
-   * -                        | Your laptop          | HPC4 cluster
-   * - Who uses it            | You alone            | Shared by hundreds of users
-   * - Starting work          | Open a terminal      | Submit a job via ``sbatch``
-   * - Getting results        | Immediately          | After the job runs (queued)
-   * - Software               | Install anything     | Load via ``module`` commands
-   * - File system            | Local SSD            | Network-mounted (NFS)
-   * - GPUs                   | Usually 0–1          | Many, shared via scheduler
++----------------------+----------------------+-----------------------------+
+|                      | Your laptop          | HPC4 cluster                |
++======================+======================+=============================+
+| Who uses it          | You alone            | Shared by hundreds of users |
++----------------------+----------------------+-----------------------------+
+| Starting work        | Open a terminal      | Submit a job via ``sbatch`` |
++----------------------+----------------------+-----------------------------+
+| Getting results      | Immediately          | After the job runs (queued) |
++----------------------+----------------------+-----------------------------+
+| Software             | Install anything     | Load via ``module`` commands|
++----------------------+----------------------+-----------------------------+
+| File system          | Local SSD            | Network-mounted (NFS)       |
++----------------------+----------------------+-----------------------------+
+| GPUs                 | Usually 0–1          | Many, shared via scheduler  |
++----------------------+----------------------+-----------------------------+
 
 Use the pages below as the main onboarding path.
 Each item includes a short description so readers can decide where to start.

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -1,0 +1,56 @@
+Quick Start
+===========
+
+Use this page as the main onboarding entry for new HPC4 users.
+
+Background
+----------
+
+HPC4 is designed for CPU-intensive computational jobs and jobs requiring GPU coprocessor support.
+It is open to all approved university researchers, while School of Science and Engineering users have higher access priority.
+
+Use the pages below as the main onboarding path.
+Each item includes a short description so readers can decide where to start.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+    :titlesonly:
+
+    access-and-authentication
+    data-and-storage
+    software-environment
+    first-job-template
+
+.. grid:: 1 2 2 2
+    :gutter: 2
+
+    .. grid-item-card:: Access and Authentication
+        :link: access-and-authentication
+        :link-type: doc
+
+        Start here if you need the login host, authentication flow, VPN expectations, or a quick check that your account access is ready.
+
+    .. grid-item-card:: Data and Storage
+        :link: data-and-storage
+        :link-type: doc
+
+        Use this page to understand where to store files on HPC4, what each path is for, and how to move data in and out safely.
+
+    .. grid-item-card:: Software Environment
+        :link: software-environment
+        :link-type: doc
+
+        Read this when you need Python, compilers, MPI, or module commands, and want a practical starting point for the HPC4 software stack.
+
+    .. grid-item-card:: Submit Your First HPC4 Job
+        :link: first-job-template
+        :link-type: doc
+
+        Follow this path for the shortest first success: create one small batch script, submit it, and confirm that it runs on a compute node.
+
+    .. grid-item-card:: More Job Submission Patterns
+        :link: job-submission
+        :link-type: doc
+
+        Continue here after the first batch job works and you need GPU, MPI, interactive ``srun``, or job-control commands such as ``squeue`` and ``scancel``.

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -10,12 +10,59 @@ Quick Start
     | Last updated: 2026-06-04
 
 Use this page as the main onboarding entry for new HPC4 users.
+If you received a welcome email with your initial credentials,
+it was generated from the
+`HPC Account Email Generator <https://github.com/hkust-hpc-team/hpc-account-email-generator>`__
+— keep that email handy as you follow this guide.
 
-Background
-----------
+.. _understanding-the-cluster:
 
-HPC4 is designed for CPU-intensive computational jobs and jobs requiring GPU coprocessor support.
-It is open to approved university researchers.
+Understanding the Cluster
+--------------------------
+
+What is an HPC cluster?
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A cluster is many computers (*nodes*) connected by a high-speed network
+and managed as a single shared system.  Hundreds of people use it at the
+same time.  HPC4 provides:
+
+- **Login nodes** — where you land when you SSH in.  Shared by everyone.
+  Use them only for editing files, light compiling, submitting jobs, and
+  transferring data.  **Do not run heavy computations on login nodes** —
+  they will be killed by the system administrators.
+
+- **Compute nodes** — the machines that actually run your work.  They
+  come in CPU-only and GPU-equipped variants.  You never SSH directly to
+  them; instead you submit jobs to the scheduler.
+
+The HPC4 scheduler: Slurm
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Slurm is the software that manages access to compute nodes.  Think of it as a
+restaurant host:
+
+- You tell Slurm what resources you need (CPUs, memory, time, GPUs)
+  by writing a *batch script*.
+- Slurm puts your job in a queue and starts it when resources are free.
+- Requesting **more** resources than you need will make you wait **longer**.
+  Start small, measure, then scale up.
+
+Slurm also enforces fair sharing: no single user can monopolise the cluster.
+
+Cluster vs your laptop
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+
+   * -                        | Your laptop          | HPC4 cluster
+   * - Who uses it            | You alone            | Shared by hundreds of users
+   * - Starting work          | Open a terminal      | Submit a job via ``sbatch``
+   * - Getting results        | Immediately          | After the job runs (queued)
+   * - Software               | Install anything     | Load via ``module`` commands
+   * - File system            | Local SSD            | Network-mounted (NFS)
+   * - GPUs                   | Usually 0–1          | Many, shared via scheduler
 
 Use the pages below as the main onboarding path.
 Each item includes a short description so readers can decide where to start.
@@ -29,6 +76,7 @@ Each item includes a short description so readers can decide where to start.
     data-and-storage
     software-environment
     first-job-template
+    job-submission
 
 .. grid:: 1 2 2 2
     :gutter: 2

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -84,15 +84,47 @@ details.
 
 **Workflow**
 
-.. mermaid:: slurm-flow.mmd
-   :alt: Slurm workflow: ① You → sbatch → ② Queue → schedule → ③ Scheduler → allocate → ④ Job runs → ⑤ Output files. Development loop: test small → check → debug/scale → resubmit.
+.. mermaid::
+   :alt: Slurm workflow: ① You → sbatch → ② Queue → schedule → ③ Scheduler → allocate → ④ Job runs → ⑤ Output files.
    :align: center
+
+   graph TD
+       you["① You<br/>write batch script<br/>request CPUs, GPUs,<br/>memory, walltime"]
+       queue["② Slurm Queue<br/>jobs wait in line<br/>for available resources"]
+       sched["③ Scheduler<br/>decides when and where<br/>your job runs"]
+       run["④ Job runs<br/>on compute node<br/>(you may log out)"]
+       out["⑤ Output files<br/>slurm-jobid.out<br/>in /scratch or /project"]
+
+       you -->|"sbatch"| queue
+       queue -->|"schedule"| sched
+       sched -->|"allocate"| run
+       run -.->|"async"| out
+
+       style you fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+       style queue fill:#ffedd5,stroke:#ea580c,color:#7c2d12
+       style sched fill:#fee2e2,stroke:#b91c1c,color:#7f1d1d
+       style run fill:#dcfce7,stroke:#15803d,color:#14532d
+       style out fill:#dcfce7,stroke:#15803d,color:#14532d
 
 **Recommended workflow: start small, then scale up**
 
-.. mermaid:: slurm-dev-loop.mmd
+.. mermaid::
    :alt: Development cycle: test with small job → inspect output → fix errors or scale up resources → repeat.
    :align: center
+
+   graph TD
+       test["Test small<br/>short walltime, few CPUs"]
+       check["Check output<br/>squeue / sacct<br/>debug errors"]
+       scale["Scale up<br/>request more<br/>resources"]
+
+       test -->|"inspect"| check
+       check -->|"if OK"| scale
+       scale -->|"resubmit"| test
+       check -.->|"fix error"| test
+
+       style test fill:#ede9fe,stroke:#7c3aed,color:#5b21b6
+       style check fill:#ede9fe,stroke:#7c3aed,color:#5b21b6
+       style scale fill:#ede9fe,stroke:#7c3aed,color:#5b21b6
 
 The most common beginner mistake is requesting too many resources.
 Start with a tiny test, inspect the output, and only scale up when

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -20,15 +20,11 @@ keep that email handy as you follow this guide.
 
    - SuperPOD primarily uses **container-based environments**
      (Enroot with Pyxis SLURM integration).  See :doc:`/kb/enroot/index`.
-   - The edge Spack instance is located at ``/scratch/spack/2025``
-     (not ``/opt/shared/.spack-edge``).
-   - Available partitions are ``normal``, ``preempt``, and ``cpu``.
-   - Interactive sessions have a maximum walltime of 2 hours
-     (4 hours on HPC4).
-
-   Check your welcome email and the
-   `SuperPOD website <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod>`__
-   for details.
+   - The edge Spack instance is at ``/scratch/spack/2025``
+     (not ``/opt/shared/.spack-edge``).  Module commands require a
+     login shell (``bash -l``) or sourcing Lmod explicitly.
+   - See the `SuperPOD website <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod>`__
+     for partition and quota details.
 
 .. _understanding-the-cluster:
 

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -11,9 +11,7 @@ Quick Start
 
 Use this page as the main onboarding entry for new HPC4 users.
 If you received a welcome email with your initial credentials,
-it was generated from the
-`HPC Account Email Generator <https://github.com/hkust-hpc-team/hpc-account-email-generator>`__
-— keep that email handy as you follow this guide.
+keep that email handy as you follow this guide.
 
 .. _understanding-the-cluster:
 

--- a/docs/src/quick-start/index.rst
+++ b/docs/src/quick-start/index.rst
@@ -2,29 +2,25 @@ Quick Start
 ===========
 
 .. meta::
-    :description: Quick-start onboarding path for new HPC4 users covering access, storage, software setup, and first SLURM jobs.
-    :keywords: HPC4, quick start, onboarding, SLURM, software environment, storage
+    :description: Quick-start onboarding for new HPC4 and SuperPOD users covering access, storage, software setup, and first SLURM jobs.
+    :keywords: HPC4, SuperPOD, quick start, onboarding, SLURM, software environment, storage
 
 .. rst-class:: header
 
     | Last updated: 2026-06-04
 
-Use this page as the main onboarding entry for new HPC4 users.
+Use this page as the main onboarding entry for new HPC users.
 If you received a welcome email with your initial credentials,
 keep that email handy as you follow this guide.
 
-.. note::
+This quick-start covers both **HPC4** (``hpc4.ust.hk``) and
+**SuperPOD** (``superpod.ust.hk``).
 
-   This quick-start covers **HPC4 only**.  If you are using
-   **SuperPOD** (``superpod.ust.hk``), the workflow differs:
+Official pages for partition details, quotas, policies, and
+announcements:
 
-   - SuperPOD primarily uses **container-based environments**
-     (Enroot with Pyxis SLURM integration).  See :doc:`/kb/enroot/index`.
-   - The edge Spack instance is at ``/scratch/spack/2025``
-     (not ``/opt/shared/.spack-edge``).  Module commands require a
-     login shell (``bash -l``) or sourcing Lmod explicitly.
-   - See the `SuperPOD website <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod>`__
-     for partition and quota details.
+- `HPC4 <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/hpc4>`__
+- `SuperPOD <https://itso.hkust.edu.hk/services/academic-teaching-support/high-performance-computing/superpod>`__
 
 .. _understanding-the-cluster:
 
@@ -36,7 +32,11 @@ What is an HPC cluster?
 
 A cluster is many computers (*nodes*) connected by a high-speed network
 and managed as a single shared system.  Hundreds of people use it at the
-same time.  HPC4 provides:
+same time.
+
+.. figure:: cluster-architecture.svg
+   :alt: HPC cluster architecture: user terminal → login nodes → Slurm scheduler → compute nodes (CPU/GPU) → T1 storage (/scratch, fast/temporary) → T2 storage (/home, /project, backed-up/shared).
+   :align: center
 
 - **Login nodes** — where you land when you SSH in.  Shared by everyone.
   Use them only for editing files, light compiling, submitting jobs, and
@@ -47,25 +47,131 @@ same time.  HPC4 provides:
   come in CPU-only and GPU-equipped variants.  You never SSH directly to
   them; instead you submit jobs to the scheduler.
 
-The HPC4 scheduler: Slurm
-~~~~~~~~~~~~~~~~~~~~~~~~~
+- **Storage** — network-mounted file systems shared across all nodes.
+  Tier-1 (``/scratch``) is fast but temporary.  Tier-2 (``/home``,
+  ``/project``) is backed-up and meant for long-term data.  Quotas and
+  retention policies differ between HPC4 and SuperPOD; see the official
+  pages linked above.
 
-Slurm is the software that manages access to compute nodes.  Think of it as a
-restaurant host:
+The scheduler: Slurm
+~~~~~~~~~~~~~~~~~~~~
 
-- You tell Slurm what resources you need (CPUs, memory, time, GPUs)
-  by writing a *batch script*.
-- Slurm puts your job in a queue and starts it when resources are free.
-- Requesting **more** resources than you need will make you wait **longer**.
-  Start small, measure, then scale up.
+Both HPC4 and SuperPOD use **Slurm** to manage access to compute nodes.
 
-Slurm also enforces fair sharing: no single user can monopolise the cluster.
+**How it works, in plain English**
+
+You do not run big programs on the login node.
+Instead, you write a *batch script* describing what resources you need
+(CPUs, memory, time) and which commands to run.  You hand that script to
+Slurm with ``sbatch``.  Slurm returns a **job ID immediately** — you can
+log out, go home, the job will run when resources are free.
+
+::
+
+    $ sbatch my_job.sh
+    Submitted batch job 123456
+
+    $ squeue --me
+      JOBID  PARTITION  NAME     USER  ST  TIME  NODES
+     123456  amd        my_job   user  PD   0:00  1
+
+    # ... later, when the job finishes ...
+
+    $ cat slurm-123456.out
+
+That is the entire mental model.  The rest of this section explains the
+details.
+
+**Workflow**
+
+.. mermaid:: slurm-flow.mmd
+   :alt: Slurm workflow: ① You → sbatch → ② Queue → schedule → ③ Scheduler → allocate → ④ Job runs → ⑤ Output files. Development loop: test small → check → debug/scale → resubmit.
+   :align: center
+
+**Recommended workflow: start small, then scale up**
+
+.. mermaid:: slurm-dev-loop.mmd
+   :alt: Development cycle: test with small job → inspect output → fix errors or scale up resources → repeat.
+   :align: center
+
+The most common beginner mistake is requesting too many resources.
+Start with a tiny test, inspect the output, and only scale up when
+you are sure everything works.
+
+**Job size — smaller box = scheduled sooner**
+
+.. figure:: job-box.svg
+   :alt: 3D box diagram: a job is a box with three dimensions — computing (cpu/gpu) ↑, memory ↗, time →. Big box takes more space; small box fits into gaps via backfill.
+   :align: center
+
+A job is a box of resources × memory × time.  Smaller boxes fit into
+gaps that larger jobs cannot use — this is called *backfill scheduling*.
+Start small, measure resource utilization with ``glances`` or ``nvidia-smi``, then scale up.
+
+**How to choose your first resource request**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Resource
+     - Start with
+     - Slurm flag
+     - Scale up if
+   * - CPUs
+     - 4
+     - ``--cpus-per-task=4``
+     - your code uses more cores
+   * - Memory
+     - auto-allocated
+     - *do not set* (both clusters allocate automatically)
+     - job is killed by OOM
+   * - GPUs
+     - 0 (CPU job) or ≥1 (GPU job)
+     - ``--gpus-per-node=1``
+     - your code uses GPU libraries
+
+.. note::
+
+   On both HPC4 and SuperPOD, **do not set** ``--mem`` or ``--mem-per-cpu``.
+   Memory is allocated proportionally based on the number of CPUs or GPUs
+   requested.  Setting it manually can conflict with the scheduler.
+
+**Useful commands**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command
+     - Purpose
+   * - ``sbatch script.sh``
+     - Submit a job
+   * - ``squeue --me``
+     - Check your jobs
+   * - ``sacct -j <jobid>``
+     - Job history / resource usage
+   * - ``scancel <jobid>``
+     - Cancel a job
+
+**How to check if your job succeeded**
+
+.. code-block:: text
+
+    $ squeue --me                # while waiting/running
+      JOBID  PARTITION  NAME     USER  ST  TIME  NODES
+     123456  amd        my_job   user  R    2:30  1
+
+    $ sacct -j 123456            # after job finishes
+      JobID    State    ExitCode  Elapsed
+      123456   COMPLETED  0       00:02:30
+
+    $ cat slurm-123456.out       # check your output
+    Hello from cpu42
 
 Cluster vs your laptop
 ~~~~~~~~~~~~~~~~~~~~~~
 
 +----------------------+----------------------+-----------------------------+
-|                      | Your laptop          | HPC4 cluster                |
+|                      | Your laptop          | HPC4 / SuperPOD             |
 +======================+======================+=============================+
 | Who uses it          | You alone            | Shared by hundreds of users |
 +----------------------+----------------------+-----------------------------+
@@ -79,6 +185,47 @@ Cluster vs your laptop
 +----------------------+----------------------+-----------------------------+
 | GPUs                 | Usually 0–1          | Many, shared via scheduler  |
 +----------------------+----------------------+-----------------------------+
+
+Key differences between HPC4 and SuperPOD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
++-----------------------------+-----------------------------------+------------------------------------+
+|                             | HPC4                              | SuperPOD                           |
++=============================+===================================+====================================+
+| Login host                  | ``hpc4.ust.hk``                   | ``superpod.ust.hk``                |
++-----------------------------+-----------------------------------+------------------------------------+
+| Edge Spack                  | ``/opt/shared/.spack-edge``       | ``/scratch/spack/2025``            |
++-----------------------------+-----------------------------------+------------------------------------+
+| Recommended approach        | Spack + Lmod modules              | Container-based (Enroot/Pyxis)     |
++-----------------------------+-----------------------------------+------------------------------------+
+| GPU partitions              | ``gpu-a30``, ``gpu-l20``,         | ``normal``                         |
+|                             | ``gpu-rtx5880``, ``gpu-rtx4090d`` |                                    |
++-----------------------------+-----------------------------------+------------------------------------+
+| CPU partitions              | ``amd``, ``intel``                | ``cpu`` (preprocessing)            |
++-----------------------------+-----------------------------------+------------------------------------+
+
+See :doc:`/software/software-support-overview` (HPC4) and :doc:`/kb/enroot/index`
+(SuperPOD) for more detailed software documentation.
+
+Acknowledgement
+~~~~~~~~~~~~~~~
+
+.. important::
+
+   If your research makes use of HPC4 or SuperPOD, please include the
+   appropriate acknowledgement in your publication, thesis, or
+   presentation.  Also send a copy or URL of your work to the cluster
+   support team.
+
+   **HPC4**: *The computations in this work were performed on the High
+   Performance Computing facilities, HKUST HPC4, provided by ITSO, The
+   Hong Kong University of Science and Technology.*
+   → ``hpc4support@ust.hk``
+
+   **SuperPOD**: *The computations in this work were performed on the
+   High Performance Computing facilities, HKUST SuperPOD, provided by
+   ITSO, The Hong Kong University of Science and Technology (HKUST).*
+   → ``spodsupport@ust.hk``
 
 Use the pages below as the main onboarding path.
 Each item includes a short description so readers can decide where to start.
@@ -107,21 +254,21 @@ Each item includes a short description so readers can decide where to start.
         :link: data-and-storage
         :link-type: doc
 
-        Use this page to understand where to store files on HPC4, what each path is for, and how to move data in and out safely.
+        Use this page to understand where to store files, what each path is for, and how to move data in and out safely.
 
     .. grid-item-card:: Software Environment
         :link: software-environment
         :link-type: doc
 
-        Read this when you need Python, compilers, MPI, or module commands, and want a practical starting point for the HPC4 software stack.
+        Read this when you need Python, compilers, MPI, or module commands, and want a practical starting point for the HPC software stack.
 
-    .. grid-item-card:: Submit Your First HPC4 Job
+    .. grid-item-card:: Submit Your First Job
         :link: first-job-template
         :link-type: doc
 
         Follow this path for the shortest first success: create one small batch script, submit it, and confirm that it runs on a compute node.
 
-    .. grid-item-card:: More Job Submission Patterns
+    .. grid-item-card:: Job Templates and Control
         :link: job-submission
         :link-type: doc
 

--- a/docs/src/quick-start/job-box.svg
+++ b/docs/src/quick-start/job-box.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 430" font-family="Arial, Helvetica, sans-serif">
+  <rect width="700" height="430" fill="#fff"/>
+  <defs>
+    <linearGradient id="tg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff7cc"/>
+      <stop offset="100%" stop-color="#fde68a"/>
+    </linearGradient>
+    <linearGradient id="fg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fcd34d"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+    <linearGradient id="sg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d97706"/>
+      <stop offset="100%" stop-color="#92400e"/>
+    </linearGradient>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#374151"/>
+    </marker>
+    <marker id="grn" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#15803d"/>
+    </marker>
+  </defs>
+
+  <text x="350" y="36" text-anchor="middle" font-size="18" font-weight="800" fill="#1f2937">Job size — smaller box = scheduled sooner</text>
+
+  <!-- Axes: origin lower-left (55, 335) -->
+  <g stroke="#374151" stroke-width="2.5" fill="none">
+    <line x1="55" y1="335" x2="55" y2="76" marker-end="url(#arrow)"/>
+    <line x1="55" y1="335" x2="610" y2="335" marker-end="url(#arrow)"/>
+    <line x1="55" y1="335" x2="85" y2="313" marker-end="url(#arrow)"/>
+  </g>
+  <g fill="#374151">
+    <text x="60" y="72" font-size="13" font-weight="700">Computing</text>
+    <text x="60" y="87" font-size="10" fill="#6b7280">CPUs / GPUs</text>
+    <text x="615" y="331" font-size="13" font-weight="700">--time</text>
+    <text x="615" y="346" font-size="10" fill="#6b7280">walltime</text>
+  </g>
+  <!-- memory label below baseline, left-anchored; z-axis stub points in this direction -->
+  <text x="57" y="356" font-size="10" fill="#9ca3af">&#x2197; memory (auto-allocated)</text>
+
+  <!-- Big Job 1 (running): translate(90,335), front 145×130, depth (45,−26) -->
+  <!-- front-right x=235, back-right x=280 -->
+  <g transform="translate(90 335)">
+    <polygon points="0,-130 145,-130 190,-156 45,-156" fill="url(#tg)" stroke="#78350f" stroke-width="1.5"/>
+    <polygon points="0,0 145,0 145,-130 0,-130" fill="url(#fg)" stroke="#78350f" stroke-width="1.5"/>
+    <polygon points="145,0 190,-26 190,-156 145,-130" fill="url(#sg)" stroke="#78350f" stroke-width="1.5"/>
+    <text x="72" y="-72" text-anchor="middle" font-size="20" font-weight="800" fill="#fff">Big job</text>
+    <text x="72" y="-50" text-anchor="middle" font-size="13" fill="#fff">256 CPUs · 24 h</text>
+  </g>
+
+  <!-- Small Job (in gap): translate(295,335), front 40×36, depth (14,−8) -->
+  <!-- proportional ~0.28× of big job; back-right x=349 -->
+  <g transform="translate(295 335)">
+    <polygon points="0,-36 40,-36 54,-44 14,-44" fill="url(#tg)" stroke="#78350f" stroke-width="1.5"/>
+    <polygon points="0,0 40,0 40,-36 0,-36" fill="url(#fg)" stroke="#78350f" stroke-width="1.5"/>
+    <polygon points="40,0 54,-8 54,-44 40,-36" fill="url(#sg)" stroke="#78350f" stroke-width="1.5"/>
+  </g>
+  <text x="315" y="352" text-anchor="middle" font-size="10" fill="#6b7280">8 CPUs · 15 min</text>
+
+  <!-- "smaller job runs sooner" label + arrow to small job top -->
+  <rect x="237" y="167" width="166" height="25" rx="12" fill="#dcfce7" stroke="#15803d" stroke-width="1.5"/>
+  <text x="320" y="184" text-anchor="middle" font-size="13" font-style="italic" font-weight="700" fill="#15803d">smaller job runs sooner</text>
+  <line x1="320" y1="193" x2="320" y2="287" stroke="#15803d" stroke-width="1.8" stroke-dasharray="5,4" marker-end="url(#grn)"/>
+
+  <!-- Big Job 2 (queued): translate(363,335), same size as Big Job 1, dashed gray -->
+  <g transform="translate(363 335)">
+    <polygon points="0,-130 145,-130 190,-156 45,-156" fill="#f3f4f6" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="8,5"/>
+    <polygon points="0,0 145,0 145,-130 0,-130" fill="#e5e7eb" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="8,5"/>
+    <polygon points="145,0 190,-26 190,-156 145,-130" fill="#d1d5db" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="8,5"/>
+    <text x="72" y="-72" text-anchor="middle" font-size="19" font-weight="800" fill="#9ca3af">Big job</text>
+    <text x="72" y="-50" text-anchor="middle" font-size="12" fill="#9ca3af">256 CPUs · 24 h</text>
+    <text x="72" y="-30" text-anchor="middle" font-size="12" font-style="italic" fill="#9ca3af">(queued)</text>
+  </g>
+
+  <text x="350" y="412" text-anchor="middle" font-size="13" font-style="italic" fill="#6b7280">Start small, measure with glances / nvidia-smi, then scale up.</text>
+</svg>

--- a/docs/src/quick-start/job-submission.rst
+++ b/docs/src/quick-start/job-submission.rst
@@ -38,7 +38,7 @@ Use your own account and partition values from that query.
 Example output from one HPC4 account included entries for:
 
 - account ``hpcintern`` on partitions ``amd`` and ``intel``
-- account ``hpcintern`` on GPU partitions such as ``gpu-rtx4090d``, ``gpu-rtx5880``, ``gpu-l20``, and ``gpu-a30``
+- account ``hpcintern`` on GPU partitions such as ``gpu-a30``, ``gpu-l20``, and ``gpu-rtx5880``
 
 One tested CPU combination on one account was:
 

--- a/docs/src/quick-start/job-submission.rst
+++ b/docs/src/quick-start/job-submission.rst
@@ -1,0 +1,314 @@
+Job Submission
+==============
+
+This page extends :doc:`first-job-template`.
+Use it after your first simple CPU batch job already works and you need GPU, MPI, interactive, or job-control patterns.
+
+Environment
+-----------
+
+    - Users who can already log in to HPC4
+    - Users who already know their available SLURM account and partition
+    - Basic familiarity with shell commands and text editors
+
+Before You Submit
+-----------------
+
+Before writing a job script, confirm your SLURM association and available partitions.
+
+.. code-block:: bash
+
+    sacctmgr show user <username> withassoc
+
+Use your own account and partition values from that query.
+
+.. important::
+
+    Replace placeholders such as ``<username>``, ``<your-account>``, ``<your-gpu-partition>``, and ``<job_id>`` before running the commands.
+    If you type the angle brackets literally, the shell will treat them as redirection syntax and the command will fail.
+
+Example output from one HPC4 account included entries for:
+
+- account ``hpcintern`` on partitions ``amd`` and ``intel``
+- account ``hpcintern`` on GPU partitions such as ``gpu-rtx40+``, ``gpu-l20``, and ``gpu-a30``
+
+One tested CPU combination on one account was:
+
+- ``--account=hpcintern`` with ``--partition=amd``
+
+SLURM Templates
+---------------
+
+CPU Batch Template
+~~~~~~~~~~~~~~~~~~
+
+Use this for a simple non-MPI CPU job.
+
+If ``sbatch`` reports ``Invalid account or account/partition combination specified``, re-check your ``#SBATCH --account`` and ``#SBATCH --partition`` pair against the output of ``sacctmgr show user <username> withassoc``.
+One tested script only succeeded after the account and partition values were corrected to a valid pair.
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=cpu-quick-start
+    #SBATCH --output=cpu-%j.out
+    #SBATCH --time=00:30:00
+    #SBATCH --nodes=1
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=1
+    #SBATCH --account=<your-account>
+    #SBATCH --partition=amd
+
+    python my_script.py
+
+GPU Batch Template
+~~~~~~~~~~~~~~~~~~
+
+Use this when your application needs one GPU.
+
+One tested HPC4 batch script used ``--account=hpcintern``, ``--partition=gpu-a30``, and ``--gres=gpu:1``.
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=gpu-quick-start
+    #SBATCH --output=gpu-%j.out
+    #SBATCH --time=00:10:00
+    #SBATCH --nodes=1
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=8
+    #SBATCH --account=<your-account>
+    #SBATCH --partition=<your-gpu-partition>
+    #SBATCH --gres=gpu:1
+
+    nvidia-smi
+    hostname
+
+One tested submission returned ``Submitted batch job 1405013`` and produced output that included ``NVIDIA A30`` followed by ``gpu01``.
+
+MPI Batch Template
+~~~~~~~~~~~~~~~~~~
+
+Use this when your application launches multiple ranks.
+
+One tested HPC4 batch script used one node on ``amd`` with two tasks and ran ``srun -n 2 hostname``.
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=mpi-quick-start
+    #SBATCH --output=mpi-%j.out
+    #SBATCH --time=00:10:00
+    #SBATCH --nodes=1
+    #SBATCH --ntasks=2
+    #SBATCH --account=<your-account>
+    #SBATCH --partition=amd
+
+    module load intel-oneapi-compilers/2024.1.0-imjimv2
+    module load openmpi/5.0.3-65bzfqx
+
+    srun -n 2 hostname
+
+One tested submission returned ``Submitted batch job 1405014`` and produced:
+
+.. code-block:: text
+
+    cpu74
+    cpu74
+
+.. important::
+
+   On HPC4, prefer ``srun`` in SLURM jobs.
+   Do not assume ``mpirun`` or ``mpiexec`` is the recommended launcher for the provided OpenMPI build.
+
+Real-time Status Viewing
+------------------------
+
+After submitting a batch script with ``sbatch``, monitor it with ``squeue``.
+
+Check all of your jobs:
+
+.. code-block:: bash
+
+    squeue -u $USER
+
+Example output from one HPC4 login-node session:
+
+.. code-block:: text
+
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+
+If no jobs are running or pending, you may only see the header line.
+
+Check one specific job:
+
+.. code-block:: bash
+
+    squeue -j <job_id>
+
+Remember to replace ``<job_id>`` with the actual numeric job ID returned by ``sbatch``.
+
+Example output from one HPC4 login-node session after a short CPU job completed:
+
+.. code-block:: text
+
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+
+If the job is very short, it may already have finished before you run ``squeue -j <job_id>``.
+
+Example output from one HPC4 login-node session while a cancel test job was still running:
+
+.. code-block:: text
+
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+           1405015       amd cancel-t wwyuenaa  R       0:04      1 cpu42
+
+Cancel a specific job:
+
+.. code-block:: bash
+
+    scancel <job_id>
+
+Example output from one HPC4 login-node session immediately after ``scancel 1405015``:
+
+.. code-block:: text
+
+             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+           1405015       amd cancel-t wwyuenaa CG       0:04      1 cpu42
+
+Cancel all of your jobs only when you really mean to do so:
+
+.. code-block:: bash
+
+    scancel -u $USER
+
+.. warning::
+
+    ``scancel -u $USER`` cancels all of your jobs, including an active interactive ``srun --pty bash`` session.
+    Use it only when you want to stop every running and pending job owned by your account.
+
+Minimal status interpretation:
+
+- ``R`` means running.
+- ``PD`` means pending.
+- ``CG`` means completing.
+- ``F`` means failed.
+
+Interactive Tasks
+-----------------
+
+Use an interactive session when you need a compute-node shell for testing, debugging, compilation, or short manual runs.
+
+CPU interactive session example:
+
+.. code-block:: bash
+
+    srun --account=<your-account> \
+         --partition=amd \
+         --nodes=1 \
+         --ntasks=1 \
+         --cpus-per-task=4 \
+         --time=00:10:00 \
+         --pty bash
+
+GPU interactive session example:
+
+.. code-block:: bash
+
+    srun --account=<your-account> \
+         --partition=<your-gpu-partition> \
+         --nodes=1 \
+         --ntasks=1 \
+         --cpus-per-task=8 \
+         --gres=gpu:1 \
+         --time=00:10:00 \
+         --pty bash
+
+.. important::
+
+    Do not request GPU resources together with a CPU-only partition such as ``amd``.
+    On one tested HPC4 account, ``--gpus-per-task=1`` and ``--gpus=1`` were both rejected on ``gpu-a30``.
+    The tested working form was ``--gres=gpu:1`` on ``--partition=gpu-a30``.
+
+One tested failure case requested GPU resources on ``--partition=amd`` and returned:
+
+.. code-block:: text
+
+    srun: error: Unable to allocate resources: Requested node configuration is not available
+
+One tested failure case requested ``--gpus-per-task=1`` on ``--partition=gpu-a30`` and returned a resource-limit error stating that 0 GPUs were requested.
+
+Once the session starts, run a small check such as:
+
+.. code-block:: bash
+
+    hostname
+    pwd
+
+Example output from one HPC4 login-node session:
+
+.. code-block:: text
+
+    srun: job 1404966 queued and waiting for resources
+    srun: job 1404966 has been allocated resources
+    [wwyuenaa@cpu69 ~]$ hostname
+    cpu69
+    [wwyuenaa@cpu69 ~]$ pwd
+    /home/wwyuenaa
+
+If you requested a GPU, also check:
+
+.. code-block:: bash
+
+    nvidia-smi
+
+If you are not actually on a GPU node, ``nvidia-smi`` may not be available.
+
+Example output from one HPC4 GPU interactive session:
+
+.. code-block:: text
+
+    srun: job 1405005 queued and waiting for resources
+    srun: job 1405005 has been allocated resources
+    Thu Jun  4 16:10:31 2026
+    | NVIDIA A30 |
+    gpu01
+    /home/wwyuenaa
+
+Leave the interactive session with:
+
+.. code-block:: bash
+
+    exit
+
+Practical Notes
+---------------
+
+- Use short walltimes while testing.
+- Keep output files named with ``%j`` so different runs do not overwrite each other.
+- Use batch jobs for unattended work and interactive sessions for short manual checks.
+- Avoid heavy compilation or long-running tasks on login nodes.
+- If a command example contains angle-bracket placeholders, replace them before pressing Enter.
+- A very short batch job may finish before ``squeue -j <job_id>`` shows anything useful.
+
+Minimal Successful Batch Example
+--------------------------------
+
+One tested short CPU script was submitted successfully with ``sbatch`` and produced a normal output file.
+
+Example submission output:
+
+.. code-block:: text
+
+    Submitted batch job 1404973
+
+Example output file content:
+
+.. code-block:: text
+
+    Hello from cpu13
+
+See Also
+--------
+
+- :doc:`first-job-template`

--- a/docs/src/quick-start/job-submission.rst
+++ b/docs/src/quick-start/job-submission.rst
@@ -1,6 +1,14 @@
 Job Submission
 ==============
 
+.. meta::
+    :description: Quick-start SLURM guide for HPC4 users covering CPU, GPU, MPI, interactive sessions, and basic job control.
+    :keywords: HPC4, SLURM, sbatch, srun, squeue, scancel, GPU, MPI
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 This page extends :doc:`first-job-template`.
 Use it after your first simple CPU batch job already works and you need GPU, MPI, interactive, or job-control patterns.
 
@@ -30,7 +38,7 @@ Use your own account and partition values from that query.
 Example output from one HPC4 account included entries for:
 
 - account ``hpcintern`` on partitions ``amd`` and ``intel``
-- account ``hpcintern`` on GPU partitions such as ``gpu-rtx40+``, ``gpu-l20``, and ``gpu-a30``
+- account ``hpcintern`` on GPU partitions such as ``gpu-rtx4090d``, ``gpu-rtx5880``, ``gpu-l20``, and ``gpu-a30``
 
 One tested CPU combination on one account was:
 
@@ -58,6 +66,9 @@ One tested script only succeeded after the account and partition values were cor
     #SBATCH --cpus-per-task=1
     #SBATCH --account=<your-account>
     #SBATCH --partition=amd
+
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module load python/3.13.2
 
     python my_script.py
 
@@ -92,6 +103,7 @@ MPI Batch Template
 Use this when your application launches multiple ranks.
 
 One tested HPC4 batch script used one node on ``amd`` with two tasks and ran ``srun -n 2 hostname``.
+On the edge Spack instance, load a compiler first so that the hierarchical Lmod tree exposes ``openmpi``.
 
 .. code-block:: bash
 
@@ -104,8 +116,9 @@ One tested HPC4 batch script used one node on ``amd`` with two tasks and ran ``s
     #SBATCH --account=<your-account>
     #SBATCH --partition=amd
 
-    module load intel-oneapi-compilers/2024.1.0-imjimv2
-    module load openmpi/5.0.3-65bzfqx
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module load intel-oneapi-compilers/2025.0.4
+    module load openmpi/5.0.6
 
     srun -n 2 hostname
 
@@ -161,7 +174,7 @@ Example output from one HPC4 login-node session while a cancel test job was stil
 .. code-block:: text
 
              JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-           1405015       amd cancel-t wwyuenaa  R       0:04      1 cpu42
+           1405015       amd cancel-t <username>  R       0:04      1 cpu42
 
 Cancel a specific job:
 
@@ -174,7 +187,7 @@ Example output from one HPC4 login-node session immediately after ``scancel 1405
 .. code-block:: text
 
              JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-           1405015       amd cancel-t wwyuenaa CG       0:04      1 cpu42
+           1405015       amd cancel-t <username> CG       0:04      1 cpu42
 
 Cancel all of your jobs only when you really mean to do so:
 
@@ -251,10 +264,10 @@ Example output from one HPC4 login-node session:
 
     srun: job 1404966 queued and waiting for resources
     srun: job 1404966 has been allocated resources
-    [wwyuenaa@cpu69 ~]$ hostname
+    [<username>@cpu69 ~]$ hostname
     cpu69
-    [wwyuenaa@cpu69 ~]$ pwd
-    /home/wwyuenaa
+    [<username>@cpu69 ~]$ pwd
+    /home/<username>
 
 If you requested a GPU, also check:
 
@@ -273,7 +286,7 @@ Example output from one HPC4 GPU interactive session:
     Thu Jun  4 16:10:31 2026
     | NVIDIA A30 |
     gpu01
-    /home/wwyuenaa
+    /home/<username>
 
 Leave the interactive session with:
 
@@ -312,3 +325,6 @@ See Also
 --------
 
 - :doc:`first-job-template`
+- :doc:`/software/software-support-overview`
+- :doc:`How to Submit and Run Batch Jobs with SLURM </kb/slurm/slurm-how-to-submit-and-run-batch-jobs-G75o-i>`
+- :doc:`How to Request Interactive Sessions </kb/slurm/slurm-how-to-request-interactive-sessi-HV7WS9>`

--- a/docs/src/quick-start/job-submission.rst
+++ b/docs/src/quick-start/job-submission.rst
@@ -1,9 +1,9 @@
-Job Submission
-==============
+Job Templates and Control
+=========================
 
 .. meta::
-    :description: Quick-start SLURM guide for HPC4 users covering CPU, GPU, MPI, interactive sessions, and basic job control.
-    :keywords: HPC4, SLURM, sbatch, srun, squeue, scancel, GPU, MPI
+    :description: Quick-start SLURM guide for HPC4 and SuperPOD users covering CPU, GPU, MPI, interactive sessions, and basic job control.
+    :keywords: HPC4, SuperPOD, SLURM, sbatch, srun, squeue, scancel, GPU, MPI
 
 .. rst-class:: header
 
@@ -15,7 +15,7 @@ Use it after your first simple CPU batch job already works and you need GPU, MPI
 Environment
 -----------
 
-    - Users who can already log in to HPC4
+    - Users who can already log in to the cluster (HPC4 or SuperPOD)
     - Users who already know their available SLURM account and partition
     - Basic familiarity with shell commands and text editors
 
@@ -26,23 +26,26 @@ Before writing a job script, confirm your SLURM association and available partit
 
 .. code-block:: bash
 
-    sacctmgr show user <username> withassoc
+    sacctmgr show user $USER withassoc
+
+Example output (your account and partitions will differ):
+
+.. code-block:: text
+
+       User    Def Acct     Admin    Cluster    Account  Partition     Share   Priority  MaxJobs  MaxNodes  MaxCPUs  MaxSubmit  MaxWall  MaxCPUMins  QOS   Def QOS  GrpCPUs  GrpJobs  GrpNodes  GrpSubmit  GrpWall  GrpCPUMins
+    --------- ---------- --------- ---------- ---------- ---------- --------- --------- -------- --------- -------- ---------- -------- ---------- ----- -------- -------- -------- --------- ---------- -------- -----------
+       alice        itsc      None       hpc4        itsc        amd         1                                                      normal
+       alice        itsc      None       hpc4        itsc       intel        1                                                      normal
+       alice        itsc      None       hpc4        itsc     gpu-a30        1                                                      normal
+       alice        itsc      None       hpc4        itsc     gpu-l20        1                                                      normal
 
 Use your own account and partition values from that query.
 
-.. important::
+.. warning::
 
-    Replace placeholders such as ``<username>``, ``<your-account>``, ``<your-gpu-partition>``, and ``<job_id>`` before running the commands.
-    If you type the angle brackets literally, the shell will treat them as redirection syntax and the command will fail.
-
-Example output from one HPC4 account included entries for:
-
-- account ``hpcintern`` on partitions ``amd`` and ``intel``
-- account ``hpcintern`` on GPU partitions such as ``gpu-a30``, ``gpu-l20``, and ``gpu-rtx5880``
-
-One tested CPU combination on one account was:
-
-- ``--account=hpcintern`` with ``--partition=amd``
+   If ``sbatch`` reports ``Invalid account or account/partition combination specified``,
+   re-check your ``#SBATCH --account`` and ``#SBATCH --partition`` pair against the
+   output of ``sacctmgr show user $USER withassoc``.
 
 SLURM Templates
 ---------------
@@ -51,9 +54,6 @@ CPU Batch Template
 ~~~~~~~~~~~~~~~~~~
 
 Use this for a simple non-MPI CPU job.
-
-If ``sbatch`` reports ``Invalid account or account/partition combination specified``, re-check your ``#SBATCH --account`` and ``#SBATCH --partition`` pair against the output of ``sacctmgr show user <username> withassoc``.
-One tested script only succeeded after the account and partition values were corrected to a valid pair.
 
 .. code-block:: bash
 
@@ -72,12 +72,18 @@ One tested script only succeeded after the account and partition values were cor
 
     python my_script.py
 
+Create ``my_script.py`` alongside ``submit.sh``:
+
+.. code-block:: python
+
+    import platform
+    print(f"Hello from {platform.node()}")
+    print(f"Python {platform.python_version()}")
+
 GPU Batch Template
 ~~~~~~~~~~~~~~~~~~
 
 Use this when your application needs one GPU.
-
-One tested HPC4 batch script used ``--account=hpcintern``, ``--partition=gpu-a30``, and ``--gres=gpu:1``.
 
 .. code-block:: bash
 
@@ -90,19 +96,15 @@ One tested HPC4 batch script used ``--account=hpcintern``, ``--partition=gpu-a30
     #SBATCH --cpus-per-task=8
     #SBATCH --account=<your-account>
     #SBATCH --partition=<your-gpu-partition>
-    #SBATCH --gres=gpu:1
+    #SBATCH --gpus-per-node=1
 
     nvidia-smi
     hostname
-
-One tested submission returned ``Submitted batch job 1405013`` and produced output that included ``NVIDIA A30`` followed by ``gpu01``.
 
 MPI Batch Template
 ~~~~~~~~~~~~~~~~~~
 
 Use this when your application launches multiple ranks.
-
-One tested HPC4 batch script used one node on ``amd`` with two tasks and ran ``srun -n 2 hostname``.
 On the edge Spack instance, load a compiler first so that the hierarchical Lmod tree exposes ``openmpi``.
 
 .. code-block:: bash
@@ -122,13 +124,6 @@ On the edge Spack instance, load a compiler first so that the hierarchical Lmod 
 
     srun -n 2 hostname
 
-One tested submission returned ``Submitted batch job 1405014`` and produced:
-
-.. code-block:: text
-
-    cpu74
-    cpu74
-
 .. important::
 
    On HPC4, prefer ``srun`` in SLURM jobs.
@@ -143,62 +138,41 @@ Check all of your jobs:
 
 .. code-block:: bash
 
-    squeue -u $USER
+    squeue --me
 
-Example output from one HPC4 login-node session:
+Example output while a job is running:
 
 .. code-block:: text
 
-             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+              JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
+            1405015       amd cpu-quick    alice  R       0:04      1 cpu42
 
-If no jobs are running or pending, you may only see the header line.
+If no jobs are running or pending, you see only the header line.
 
 Check one specific job:
 
 .. code-block:: bash
 
-    squeue -j <job_id>
+    squeue -j 1404973
 
-Remember to replace ``<job_id>`` with the actual numeric job ID returned by ``sbatch``.
-
-Example output from one HPC4 login-node session after a short CPU job completed:
-
-.. code-block:: text
-
-             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-
-If the job is very short, it may already have finished before you run ``squeue -j <job_id>``.
-
-Example output from one HPC4 login-node session while a cancel test job was still running:
-
-.. code-block:: text
-
-             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-           1405015       amd cancel-t <username>  R       0:04      1 cpu42
+If the job is very short, it may already have finished before you run ``squeue -j``.
 
 Cancel a specific job:
 
 .. code-block:: bash
 
-    scancel <job_id>
-
-Example output from one HPC4 login-node session immediately after ``scancel 1405015``:
-
-.. code-block:: text
-
-             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-           1405015       amd cancel-t <username> CG       0:04      1 cpu42
+    scancel 1404973
 
 Cancel all of your jobs only when you really mean to do so:
 
 .. code-block:: bash
 
-    scancel -u $USER
+    scancel --me
 
 .. warning::
 
-    ``scancel -u $USER`` cancels all of your jobs, including an active interactive ``srun --pty bash`` session.
-    Use it only when you want to stop every running and pending job owned by your account.
+   ``scancel --me`` cancels all of your jobs, including an active interactive ``srun --pty bash`` session.
+   Use it only when you want to stop every running and pending job owned by your account.
 
 Minimal status interpretation:
 
@@ -233,23 +207,15 @@ GPU interactive session example:
          --nodes=1 \
          --ntasks=1 \
          --cpus-per-task=8 \
-         --gres=gpu:1 \
+         --gpus-per-node=1 \
          --time=00:10:00 \
          --pty bash
 
 .. important::
 
-    Do not request GPU resources together with a CPU-only partition such as ``amd``.
-    On one tested HPC4 account, ``--gpus-per-task=1`` and ``--gpus=1`` were both rejected on ``gpu-a30``.
-    The tested working form was ``--gres=gpu:1`` on ``--partition=gpu-a30``.
-
-One tested failure case requested GPU resources on ``--partition=amd`` and returned:
-
-.. code-block:: text
-
-    srun: error: Unable to allocate resources: Requested node configuration is not available
-
-One tested failure case requested ``--gpus-per-task=1`` on ``--partition=gpu-a30`` and returned a resource-limit error stating that 0 GPUs were requested.
+   Do not request GPU resources together with a CPU-only partition such as ``amd``.
+   On both HPC4 and SuperPOD, use ``--gpus-per-node=<n>`` to request GPUs.
+   ``--gpus-per-task`` and ``--gpus`` are not recommended on GPU partitions.
 
 Once the session starts, run a small check such as:
 
@@ -258,16 +224,16 @@ Once the session starts, run a small check such as:
     hostname
     pwd
 
-Example output from one HPC4 login-node session:
+Example output from an HPC4 CPU interactive session:
 
 .. code-block:: text
 
     srun: job 1404966 queued and waiting for resources
     srun: job 1404966 has been allocated resources
-    [<username>@cpu69 ~]$ hostname
+    [alice@cpu69 ~]$ hostname
     cpu69
-    [<username>@cpu69 ~]$ pwd
-    /home/<username>
+    [alice@cpu69 ~]$ pwd
+    /home/alice
 
 If you requested a GPU, also check:
 
@@ -277,7 +243,7 @@ If you requested a GPU, also check:
 
 If you are not actually on a GPU node, ``nvidia-smi`` may not be available.
 
-Example output from one HPC4 GPU interactive session:
+Example output from an HPC4 GPU interactive session:
 
 .. code-block:: text
 
@@ -286,7 +252,7 @@ Example output from one HPC4 GPU interactive session:
     Thu Jun  4 16:10:31 2026
     | NVIDIA A30 |
     gpu01
-    /home/<username>
+    /home/alice
 
 Leave the interactive session with:
 
@@ -301,25 +267,7 @@ Practical Notes
 - Keep output files named with ``%j`` so different runs do not overwrite each other.
 - Use batch jobs for unattended work and interactive sessions for short manual checks.
 - Avoid heavy compilation or long-running tasks on login nodes.
-- If a command example contains angle-bracket placeholders, replace them before pressing Enter.
 - A very short batch job may finish before ``squeue -j <job_id>`` shows anything useful.
-
-Minimal Successful Batch Example
---------------------------------
-
-One tested short CPU script was submitted successfully with ``sbatch`` and produced a normal output file.
-
-Example submission output:
-
-.. code-block:: text
-
-    Submitted batch job 1404973
-
-Example output file content:
-
-.. code-block:: text
-
-    Hello from cpu13
 
 See Also
 --------
@@ -328,3 +276,5 @@ See Also
 - :doc:`/software/software-support-overview`
 - :doc:`How to Submit and Run Batch Jobs with SLURM </kb/slurm/slurm-how-to-submit-and-run-batch-jobs-G75o-i>`
 - :doc:`How to Request Interactive Sessions </kb/slurm/slurm-how-to-request-interactive-sessi-HV7WS9>`
+- `HPC4 example scripts (CPU, GPU, MPI, interactive) <https://github.com/hkust-hpc-team/hkust-hpc/tree/main/examples/hpc4-hello-world>`__
+- `SuperPOD example scripts <https://github.com/hkust-hpc-team/hkust-hpc/tree/main/examples/superpod-hello-world>`__

--- a/docs/src/quick-start/software-environment.rst
+++ b/docs/src/quick-start/software-environment.rst
@@ -1,6 +1,14 @@
 Software Environment
 ====================
 
+.. meta::
+    :description: Quick-start guide to software modules, edge Spack activation, Python environments, compilers, MPI, and uv on HPC4.
+    :keywords: HPC4, Spack, Lmod, Python, anaconda3, uv, compiler, openmpi, modules
+
+.. rst-class:: header
+
+    | Last updated: 2026-06-04
+
 This page introduces the basic module commands on HPC4 and shows a few common environment setup patterns for new users.
 
 Environment
@@ -14,17 +22,17 @@ Background
 ----------
 
 HPC4 provides software environments through environment modules.
-The software stack in hkust-hpc also references Spack and Lmod, so users should expect available modules to depend on the active software environment.
-In particular, a fresh login shell may not show the software you want with a direct filtered query such as ``module avail python``.
-From the current HPC4 login-node view, the default core modules already include software such as ``anaconda3``, ``miniconda3``, ``gcc``, ``intel-oneapi-compilers``, ``mpich``, and ``openmpi``.
+The software stack in hkust-hpc uses Spack and Lmod, so available modules depend on the active software environment.
+For new work on HPC4, use the edge Spack instance instead of relying on the deprecated default instance.
+In particular, a fresh login shell may not show the software you want with a direct filtered query such as ``module avail python`` until edge Spack is activated.
 
 Practical Notes
 ---------------
 
-- On the default login-node environment, ``module avail python`` may return no match.
-- On the default login-node environment, conda-based modules such as ``anaconda3`` and ``miniconda3`` are often the most direct Python entry points.
-- The default module tree also exposes toolchains such as ``intel-oneapi-compilers`` and ``openmpi``.
-- If you switch to the edge Spack instance, direct ``python/<version>`` modules become available.
+- For new quick-start workflows, begin with ``source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y``.
+- On the default login-node environment, ``module avail python`` may return no match before edge Spack is activated.
+- After edge activation, direct modules such as ``python/<version>``, ``anaconda3/<version>``, and ``intel-oneapi-compilers/<version>`` become available.
+- On the edge Spack instance, ``openmpi`` is not a core module; load a compiler first and then load ``openmpi`` from the hierarchical Lmod tree.
 - For MPI jobs on HPC4, prefer ``srun`` in quick-start workflows.
 
 Basic Commands
@@ -32,29 +40,25 @@ Basic Commands
 
 The following commands are the minimum set most users need when starting on HPC4.
 
-Start by checking the current module view:
+Start from a clean shell and activate edge Spack:
 
 .. code-block:: bash
 
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
     module avail
 
-If a filtered ``module avail`` query returns no matches, use Lmod's broader search command:
+Then use Lmod's broader search command when you need to find software:
 
 .. code-block:: bash
 
     module spider python
 
-If ``module spider python`` also fails, use one of the Python distributions already exposed in the core module tree instead:
+For example, load a tested edge Python module:
 
 .. code-block:: bash
 
-    module load anaconda3/2023.09-0-biybti3
-
-or:
-
-.. code-block:: bash
-
-    module load miniconda3/24.3.0-quc3pyu
+    module load python/3.13.2
 
 Unload all currently loaded modules:
 
@@ -72,7 +76,7 @@ Useful follow-up checks:
 
 The exact module names and versions on your account may differ from the examples here.
 On HPC4, ``module avail python`` may print ``No module(s) or extension(s) found!`` on a fresh login session.
-The default core-module view can already show conda-based choices such as ``anaconda3/...`` and ``miniconda3/...``.
+After activating edge Spack, the module tree changes and direct Python or compiler modules become available.
 The command examples below include outputs observed during testing on one HPC4 account.
 Treat them as practical references rather than guaranteed output for every account.
 
@@ -82,14 +86,33 @@ Common Environments
 Python Environment
 ~~~~~~~~~~~~~~~~~~
 
-On the current HPC4 default module tree, the most direct Python entry points are the conda-based modules such as ``anaconda3`` and ``miniconda3``.
+For new quick-start workflows, use the edge Spack instance first and then load an explicit Python module.
 Do not assume that ``module avail python`` will work before the correct software instance is active.
 
 .. code-block:: bash
 
     module purge
-    module avail
-    module load anaconda3/2023.09-0-biybti3
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module spider python
+    module load python/3.13.2
+    python --version
+    module list
+    which python
+
+Example output from one HPC4 login-node session:
+
+- ``python --version`` reports ``Python 3.13.2``.
+- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.13.2.../bin/python``.
+- ``module list`` shows ``python/3.13.2`` loaded.
+
+If you prefer a Conda-based Python distribution on edge, use ``anaconda3`` after activating the same instance:
+
+.. code-block:: bash
+
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module spider anaconda3
+    module load anaconda3/2025
     python --version
     conda --version
     module list
@@ -97,68 +120,72 @@ Do not assume that ``module avail python`` will work before the correct software
 
 Example output from one HPC4 login-node session:
 
-- ``python --version`` reports ``Python 3.11.5``.
-- ``conda --version`` reports ``conda 23.7.4``.
-- ``which python`` points into the shared Spack Anaconda installation under ``/opt/shared/spack/.../anaconda3-2023.09-0-biybti3.../bin/python``.
-
-An alternative tested path is ``miniconda3``:
-
-.. code-block:: bash
-
-    module purge
-    module load miniconda3/24.3.0-quc3pyu
-    python --version
-    module list
-    which python
-
-Example output from one HPC4 login-node session:
-
-- ``python --version`` reports ``Python 3.12.2``.
-- ``which python`` points into the shared Spack Miniconda installation under ``/opt/shared/spack/.../miniconda3-24.3.0-quc3pyu.../bin/python``.
+- ``module list`` shows an ``anaconda3`` module from ``/opt/shared/.spack-edge`` loaded.
+- ``which python`` points into the shared Spack Anaconda installation under ``/opt/shared/.spack-edge/.../anaconda3.../bin/python``.
 
 Do not run ``module avail spider python``. That is not valid syntax.
 Use ``module spider python`` as a standalone command.
 
-If you specifically need a non-conda Python module and both ``module avail python`` and ``module spider python`` return no matches, treat that as a site-specific limitation of the current default environment rather than a typo in your command.
-On HPC4, the edge Spack path can expose direct ``python/<version>`` modules.
+If you specifically need another Python version, activate edge Spack first and then load an explicit versioned module.
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
     module spider python
-    module load python/3.13.2-sbeg36d
+    module load python/3.12.9
     python --version
     which python
     module list
 
 Example output from one HPC4 login-node session:
 
-- ``python --version`` reports ``Python 3.13.2``.
-- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.13.2-sbeg36d.../bin/python``.
-- ``module list`` shows ``python/3.13.2-sbeg36d`` loaded.
+- ``python --version`` reports ``Python 3.12.9``.
+- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9.../bin/python``.
+- ``module list`` shows ``python/3.12.9`` loaded.
+
+Using uv for Pure-Python Workflows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For pure-Python projects, ``uv`` is a fast alternative to creating a Conda environment.
+This works well when you only need a Python interpreter plus packages from PyPI.
+
+.. code-block:: bash
+
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module load python/3.13.2
+    uv venv myenv
+    source myenv/bin/activate
+    uv pip install numpy pandas matplotlib
+    python --version
+
+Use Conda-based modules when you specifically want a bundled scientific Python distribution.
+For more complete Python workflow guidance, including ``uv``, see :doc:`/software/python/python`.
 
 Compiler and MPI Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use this pattern when you need a compiler toolchain and MPI libraries.
-The following sequence is a practical example for the current HPC4 environment.
+The following sequence is a practical example for the edge Spack environment.
 
 .. code-block:: bash
 
     module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
     module spider intel-oneapi-compilers
-    module load intel-oneapi-compilers/2024.1.0-imjimv2
+    module load intel-oneapi-compilers/2025.0.4
     module spider openmpi
-    module load openmpi/5.0.3-65bzfqx
+    module load openmpi/5.0.6
     module list
 
 Example output from one HPC4 login-node session:
 
-- ``module list`` shows both ``intel-oneapi-compilers/2024.1.0-imjimv2`` and ``openmpi/5.0.3-65bzfqx`` loaded.
+- ``module list`` shows both ``intel-oneapi-compilers/2025.0.4`` and ``openmpi/5.0.6`` loaded.
 
 .. important::
 
+    On the edge Spack instance, ``openmpi`` becomes visible after you load a compiler module.
     On HPC4, this OpenMPI build warns that ``mpirun``/``mpiexec`` should not be treated as the default launcher path.
     For quick-start job scripts and routine MPI runs, prefer ``srun``.
 
@@ -170,33 +197,35 @@ If your shell environment becomes confusing, start from a clean module state.
 .. code-block:: bash
 
     module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
     module avail
 
-Spack-Backed Software Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Edge Spack Environment
+~~~~~~~~~~~~~~~~~~~~~~
 
-The hkust-hpc documentation shows that some software environments depend on the active Spack instance.
-If your site requires activating a Spack instance before using modules, do that first and then load modules.
-The following sequence is a practical example that worked on one HPC4 account.
+The hkust-hpc documentation recommends the edge Spack instance for new work.
+Activate it explicitly, verify the active variant, and then load the software you need.
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    echo $SPACK_VARIANT
     module avail
     module spider python
-    module load python/3.12.9-3lxwd5b
+    module load python/3.12.9
     python --version
     which python
     module list
 
 Example output from one HPC4 login-node session:
 
+- ``echo $SPACK_VARIANT`` reports ``edge``.
 - ``python --version`` reports ``Python 3.12.9``.
-- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9-3lxwd5b.../bin/python``.
-- ``module list`` shows ``python/3.12.9-3lxwd5b`` loaded.
+- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9.../bin/python``.
+- ``module list`` shows ``python/3.12.9`` loaded.
 
-For the default login-node environment, prefer the modules already visible in the core tree unless you specifically need software from the edge instance.
+For new quick-start workflows, prefer the edge instance instead of the deprecated default instance.
 
 .. warning::
 
@@ -206,11 +235,11 @@ Verification Checklist
 ----------------------
 
 - Run ``module avail`` successfully.
-- Confirm which software is already visible in the default core tree.
+- Activate edge Spack with ``source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y``.
 - If a filtered lookup fails, run ``module spider <name>`` before loading a module.
-- If both commands fail for Python, load ``anaconda3`` or ``miniconda3`` instead.
 - Load one module and verify the related executable is found.
-- If you activate edge Spack, verify ``$SPACK_VARIANT`` and load an explicit module version.
+- Verify ``$SPACK_VARIANT`` if you need to confirm the active software instance.
+- Load ``openmpi`` only after loading a compiler module on the edge instance.
 - For MPI jobs on HPC4, prefer ``srun`` over ``mpirun`` in quick-start workflows.
 - Run ``module list`` to confirm the expected module is active.
 - Use ``module purge`` and confirm the environment resets cleanly.
@@ -220,3 +249,10 @@ References
 
 - :doc:`/software/software-support-overview`
 - :doc:`/software/python/anaconda3`
+
+See Also
+--------
+
+- :doc:`/software/python/python`
+- :doc:`How to Request Interactive Sessions </kb/slurm/slurm-how-to-request-interactive-sessi-HV7WS9>`
+- :doc:`How to Submit and Run Batch Jobs with SLURM </kb/slurm/slurm-how-to-submit-and-run-batch-jobs-G75o-i>`

--- a/docs/src/quick-start/software-environment.rst
+++ b/docs/src/quick-start/software-environment.rst
@@ -2,171 +2,119 @@ Software Environment
 ====================
 
 .. meta::
-    :description: Quick-start guide to software modules, edge Spack activation, Python environments, compilers, MPI, and uv on HPC4.
-    :keywords: HPC4, Spack, Lmod, Python, anaconda3, uv, compiler, openmpi, modules
+    :description: Quick-start guide to software modules, edge Spack activation, Python environments, compilers, MPI, and uv on HPC4 (SuperPOD: see container workflow).
+    :keywords: HPC4, SuperPOD, Spack, Lmod, Python, anaconda3, uv, compiler, openmpi, modules
 
 .. rst-class:: header
 
     | Last updated: 2026-06-04
 
-This page introduces the basic module commands on HPC4 and shows a few common environment setup patterns for new users.
+This page covers module-based software setup for HPC4.
+SuperPOD users typically use containers (Enroot/Pyxis) but can also use the Spack instance at ``/scratch/spack/2025``.
 
 Environment
 -----------
 
-    - Users who can already log in to HPC4
+    - Users who can already log in to HPC4 (or SuperPOD)
     - Shell access on a login node or inside a job session
-    - Basic familiarity with terminal commands
 
-Background
-----------
+Quick Reference: Common Environments
+-------------------------------------
 
-HPC4 provides software environments through environment modules.
-The software stack in hkust-hpc uses Spack and Lmod, so available modules depend on the active software environment.
-For new work on HPC4, use the edge Spack instance instead of relying on the deprecated default instance.
-In particular, a fresh login shell may not show the software you want with a direct filtered query such as ``module avail python`` until edge Spack is activated.
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
 
-Practical Notes
----------------
+   * - Environment
+     - Modules to load
+     - Use case
+   * - Python (standalone)
+     - ``python/3.13.2``
+     - Pure-Python scripts, uv-based workflows
+   * - Python (Conda)
+     - ``anaconda3/2025``
+     - Packages from conda ecosystem, mixed Python + C/C++
+   * - Compiler + MPI
+     - ``intel-oneapi-compilers/2025.0.4`` then ``openmpi/5.0.6``
+     - MPI parallel jobs, compiled code
 
-- For new quick-start workflows, begin with ``source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y``.
-- On the default login-node environment, ``module avail python`` may return no match before edge Spack is activated.
-- After edge activation, direct modules such as ``python/<version>``, ``anaconda3/<version>``, and ``intel-oneapi-compilers/<version>`` become available.
-- On the edge Spack instance, ``openmpi`` is not a core module; load a compiler first and then load ``openmpi`` from the hierarchical Lmod tree.
-- For MPI jobs on HPC4, prefer ``srun`` in quick-start workflows.
+.. note::
+
+   All examples below require **edge Spack activation** first.
+   On a fresh login, ``module avail python`` may show nothing until edge is active.
 
 Basic Commands
 --------------
 
-The following commands are the minimum set most users need when starting on HPC4.
-
-Start from a clean shell and activate edge Spack:
+Every session starts the same way — activate edge Spack, then load what you need:
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module avail
 
-Then use Lmod's broader search command when you need to find software:
+Then use these commands as needed:
 
-.. code-block:: bash
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
 
-    module spider python
-
-For example, load a tested edge Python module:
-
-.. code-block:: bash
-
-    module load python/3.13.2
-
-Unload all currently loaded modules:
-
-.. code-block:: bash
-
-    module purge
-
-Useful follow-up checks:
-
-.. code-block:: bash
-
-    module list
-    which python
-    python --version
-
-The exact module names and versions on your account may differ from the examples here.
-On HPC4, ``module avail python`` may print ``No module(s) or extension(s) found!`` on a fresh login session.
-After activating edge Spack, the module tree changes and direct Python or compiler modules become available.
-The command examples below include outputs observed during testing on one HPC4 account.
-Treat them as practical references rather than guaranteed output for every account.
-
-Common Environments
--------------------
+   * - Command
+     - Purpose
+   * - ``module avail``
+     - List all available modules
+   * - ``module spider <name>``
+     - Search for a module (broader search)
+   * - ``module load <name/version>``
+     - Load a specific module
+   * - ``module list``
+     - Show currently loaded modules
+   * - ``module purge``
+     - Unload all modules
 
 Python Environment
-~~~~~~~~~~~~~~~~~~
-
-For new quick-start workflows, use the edge Spack instance first and then load an explicit Python module.
-Do not assume that ``module avail python`` will work before the correct software instance is active.
+------------------
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module spider python
     module load python/3.13.2
-    python --version
-    module list
-    which python
+    python --version        # Python 3.13.2
+    which python            # /opt/shared/.spack-edge/.../bin/python
 
-Example output from one HPC4 login-node session:
-
-- ``python --version`` reports ``Python 3.13.2``.
-- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.13.2.../bin/python``.
-- ``module list`` shows ``python/3.13.2`` loaded.
-
-If you prefer a Conda-based Python distribution on edge, use ``anaconda3`` after activating the same instance:
+For Conda-based Python:
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module spider anaconda3
     module load anaconda3/2025
     python --version
     conda --version
-    module list
-    which python
 
-Example output from one HPC4 login-node session:
-
-- ``module list`` shows an ``anaconda3`` module from ``/opt/shared/.spack-edge`` loaded.
-- ``which python`` points into the shared Spack Anaconda installation under ``/opt/shared/.spack-edge/.../anaconda3.../bin/python``.
-
-Do not run ``module avail spider python``. That is not valid syntax.
-Use ``module spider python`` as a standalone command.
-
-If you specifically need another Python version, activate edge Spack first and then load an explicit versioned module.
+For a different Python version:
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module spider python
     module load python/3.12.9
-    python --version
-    which python
-    module list
-
-Example output from one HPC4 login-node session:
-
-- ``python --version`` reports ``Python 3.12.9``.
-- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9.../bin/python``.
-- ``module list`` shows ``python/3.12.9`` loaded.
 
 Using uv for Pure-Python Workflows
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For pure-Python projects, `uv <https://docs.astral.sh/uv/>`__ is a fast,
-modern package manager that works in user space — no administrator access
-needed.  We also recommend `ruff <https://docs.astral.sh/ruff/>`__
-(a fast Python linter and formatter) as a companion tool.
+`uv <https://docs.astral.sh/uv/>`__ is a fast, modern package manager that works in user space.
 
-Install uv once on the login node:
+Install once:
 
 .. code-block:: bash
 
     curl -LsSf https://astral.sh/uv/install.sh | sh
-
-The installer places ``uv`` in ``~/.local/bin/uv``.  Add it to your
-``PATH`` for convenience:
-
-.. code-block:: bash
-
     echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
     source ~/.bashrc
 
-Basic workflow with edge Python + uv:
+Basic workflow:
 
 .. code-block:: bash
 
@@ -176,8 +124,6 @@ Basic workflow with edge Python + uv:
     uv venv
     source .venv/bin/activate
     uv pip install numpy pandas matplotlib
-    uv pip install ruff
-    python --version
 
 In a SLURM job script:
 
@@ -199,92 +145,34 @@ In a SLURM job script:
     source /path/to/project/.venv/bin/activate
     python my_script.py
 
-Use Conda-based modules (``anaconda3`` or ``miniconda3``) when you
-specifically need packages from the conda ecosystem that are not on
-PyPI, or when your project mixes Python with compiled C/C++/Fortran
-code.  For more complete Python workflow guidance, see
-:doc:`/software/python/python`.
+For more complete Python workflow guidance, see :doc:`/software/python/python`.
 
 Compiler and MPI Environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
-Use this pattern when you need a compiler toolchain and MPI libraries.
-The following sequence is a practical example for the edge Spack environment.
+Load a compiler first, then MPI — ``openmpi`` is only visible after a compiler is loaded on the edge instance.
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module spider intel-oneapi-compilers
     module load intel-oneapi-compilers/2025.0.4
-    module spider openmpi
     module load openmpi/5.0.6
     module list
 
-Example output from one HPC4 login-node session:
-
-- ``module list`` shows both ``intel-oneapi-compilers/2025.0.4`` and ``openmpi/5.0.6`` loaded.
-
 .. important::
 
-    On the edge Spack instance, ``openmpi`` becomes visible after you load a compiler module.
-    On HPC4, this OpenMPI build warns that ``mpirun``/``mpiexec`` should not be treated as the default launcher path.
-    For quick-start job scripts and routine MPI runs, prefer ``srun``.
-
-Clean Environment Reset
-~~~~~~~~~~~~~~~~~~~~~~~
-
-If your shell environment becomes confusing, start from a clean module state.
-
-.. code-block:: bash
-
-    module purge
-    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    module avail
-
-Edge Spack Environment
-~~~~~~~~~~~~~~~~~~~~~~
-
-The hkust-hpc documentation recommends the edge Spack instance for new work.
-Activate it explicitly, verify the active variant, and then load the software you need.
-
-.. code-block:: bash
-
-    module purge
-    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
-    echo $SPACK_VARIANT
-    module avail
-    module spider python
-    module load python/3.12.9
-    python --version
-    which python
-    module list
-
-Example output from one HPC4 login-node session:
-
-- ``echo $SPACK_VARIANT`` reports ``edge``.
-- ``python --version`` reports ``Python 3.12.9``.
-- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9.../bin/python``.
-- ``module list`` shows ``python/3.12.9`` loaded.
-
-For new quick-start workflows, prefer the edge instance instead of the deprecated default instance.
-
-.. warning::
-
-   Do not add Spack activation blindly to your shell startup files until you confirm that this is the recommended HPC4 practice for your account and workflow.
+    On HPC4, prefer ``srun`` over ``mpirun`` / ``mpiexec`` for MPI jobs.
 
 Verification Checklist
 ----------------------
 
-- Run ``module avail`` successfully.
-- Activate edge Spack with ``source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y``.
-- If a filtered lookup fails, run ``module spider <name>`` before loading a module.
-- Load one module and verify the related executable is found.
-- Verify ``$SPACK_VARIANT`` if you need to confirm the active software instance.
-- Load ``openmpi`` only after loading a compiler module on the edge instance.
-- For MPI jobs on HPC4, prefer ``srun`` over ``mpirun`` in quick-start workflows.
-- Run ``module list`` to confirm the expected module is active.
-- Use ``module purge`` and confirm the environment resets cleanly.
+- ``module avail`` shows available modules after edge activation
+- ``module spider <name>`` finds the module you want
+- ``module load <name/version>`` loads successfully
+- ``which <command>`` points to the expected path
+- ``module list`` confirms loaded modules
+- ``$SPACK_VARIANT`` reports ``edge`` (optional check)
 
 References
 ----------

--- a/docs/src/quick-start/software-environment.rst
+++ b/docs/src/quick-start/software-environment.rst
@@ -147,21 +147,63 @@ Example output from one HPC4 login-node session:
 Using uv for Pure-Python Workflows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For pure-Python projects, ``uv`` is a fast alternative to creating a Conda environment.
-This works well when you only need a Python interpreter plus packages from PyPI.
+For pure-Python projects, `uv <https://docs.astral.sh/uv/>`__ is a fast,
+modern package manager that works in user space — no administrator access
+needed.  We also recommend `ruff <https://docs.astral.sh/ruff/>`__
+(a fast Python linter and formatter) as a companion tool.
+
+Install uv once on the login node:
+
+.. code-block:: bash
+
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+The installer places ``uv`` in ``~/.local/bin/uv``.  Add it to your
+``PATH`` for convenience:
+
+.. code-block:: bash
+
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+    source ~/.bashrc
+
+Basic workflow with edge Python + uv:
 
 .. code-block:: bash
 
     module purge
     source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
     module load python/3.13.2
-    uv venv myenv
-    source myenv/bin/activate
+    uv venv
+    source .venv/bin/activate
     uv pip install numpy pandas matplotlib
+    uv pip install ruff
     python --version
 
-Use Conda-based modules when you specifically want a bundled scientific Python distribution.
-For more complete Python workflow guidance, including ``uv``, see :doc:`/software/python/python`.
+In a SLURM job script:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #SBATCH --job-name=my-python-job
+    #SBATCH --output=py-%j.out
+    #SBATCH --time=01:00:00
+    #SBATCH --nodes=1
+    #SBATCH --ntasks=1
+    #SBATCH --cpus-per-task=4
+    #SBATCH --account=<your-account>
+    #SBATCH --partition=amd
+
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module load python/3.13.2
+    source /path/to/project/.venv/bin/activate
+    python my_script.py
+
+Use Conda-based modules (``anaconda3`` or ``miniconda3``) when you
+specifically need packages from the conda ecosystem that are not on
+PyPI, or when your project mixes Python with compiled C/C++/Fortran
+code.  For more complete Python workflow guidance, see
+:doc:`/software/python/python`.
 
 Compiler and MPI Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/src/quick-start/software-environment.rst
+++ b/docs/src/quick-start/software-environment.rst
@@ -1,0 +1,222 @@
+Software Environment
+====================
+
+This page introduces the basic module commands on HPC4 and shows a few common environment setup patterns for new users.
+
+Environment
+-----------
+
+    - Users who can already log in to HPC4
+    - Shell access on a login node or inside a job session
+    - Basic familiarity with terminal commands
+
+Background
+----------
+
+HPC4 provides software environments through environment modules.
+The software stack in hkust-hpc also references Spack and Lmod, so users should expect available modules to depend on the active software environment.
+In particular, a fresh login shell may not show the software you want with a direct filtered query such as ``module avail python``.
+From the current HPC4 login-node view, the default core modules already include software such as ``anaconda3``, ``miniconda3``, ``gcc``, ``intel-oneapi-compilers``, ``mpich``, and ``openmpi``.
+
+Practical Notes
+---------------
+
+- On the default login-node environment, ``module avail python`` may return no match.
+- On the default login-node environment, conda-based modules such as ``anaconda3`` and ``miniconda3`` are often the most direct Python entry points.
+- The default module tree also exposes toolchains such as ``intel-oneapi-compilers`` and ``openmpi``.
+- If you switch to the edge Spack instance, direct ``python/<version>`` modules become available.
+- For MPI jobs on HPC4, prefer ``srun`` in quick-start workflows.
+
+Basic Commands
+--------------
+
+The following commands are the minimum set most users need when starting on HPC4.
+
+Start by checking the current module view:
+
+.. code-block:: bash
+
+    module avail
+
+If a filtered ``module avail`` query returns no matches, use Lmod's broader search command:
+
+.. code-block:: bash
+
+    module spider python
+
+If ``module spider python`` also fails, use one of the Python distributions already exposed in the core module tree instead:
+
+.. code-block:: bash
+
+    module load anaconda3/2023.09-0-biybti3
+
+or:
+
+.. code-block:: bash
+
+    module load miniconda3/24.3.0-quc3pyu
+
+Unload all currently loaded modules:
+
+.. code-block:: bash
+
+    module purge
+
+Useful follow-up checks:
+
+.. code-block:: bash
+
+    module list
+    which python
+    python --version
+
+The exact module names and versions on your account may differ from the examples here.
+On HPC4, ``module avail python`` may print ``No module(s) or extension(s) found!`` on a fresh login session.
+The default core-module view can already show conda-based choices such as ``anaconda3/...`` and ``miniconda3/...``.
+The command examples below include outputs observed during testing on one HPC4 account.
+Treat them as practical references rather than guaranteed output for every account.
+
+Common Environments
+-------------------
+
+Python Environment
+~~~~~~~~~~~~~~~~~~
+
+On the current HPC4 default module tree, the most direct Python entry points are the conda-based modules such as ``anaconda3`` and ``miniconda3``.
+Do not assume that ``module avail python`` will work before the correct software instance is active.
+
+.. code-block:: bash
+
+    module purge
+    module avail
+    module load anaconda3/2023.09-0-biybti3
+    python --version
+    conda --version
+    module list
+    which python
+
+Example output from one HPC4 login-node session:
+
+- ``python --version`` reports ``Python 3.11.5``.
+- ``conda --version`` reports ``conda 23.7.4``.
+- ``which python`` points into the shared Spack Anaconda installation under ``/opt/shared/spack/.../anaconda3-2023.09-0-biybti3.../bin/python``.
+
+An alternative tested path is ``miniconda3``:
+
+.. code-block:: bash
+
+    module purge
+    module load miniconda3/24.3.0-quc3pyu
+    python --version
+    module list
+    which python
+
+Example output from one HPC4 login-node session:
+
+- ``python --version`` reports ``Python 3.12.2``.
+- ``which python`` points into the shared Spack Miniconda installation under ``/opt/shared/spack/.../miniconda3-24.3.0-quc3pyu.../bin/python``.
+
+Do not run ``module avail spider python``. That is not valid syntax.
+Use ``module spider python`` as a standalone command.
+
+If you specifically need a non-conda Python module and both ``module avail python`` and ``module spider python`` return no matches, treat that as a site-specific limitation of the current default environment rather than a typo in your command.
+On HPC4, the edge Spack path can expose direct ``python/<version>`` modules.
+
+.. code-block:: bash
+
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module spider python
+    module load python/3.13.2-sbeg36d
+    python --version
+    which python
+    module list
+
+Example output from one HPC4 login-node session:
+
+- ``python --version`` reports ``Python 3.13.2``.
+- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.13.2-sbeg36d.../bin/python``.
+- ``module list`` shows ``python/3.13.2-sbeg36d`` loaded.
+
+Compiler and MPI Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use this pattern when you need a compiler toolchain and MPI libraries.
+The following sequence is a practical example for the current HPC4 environment.
+
+.. code-block:: bash
+
+    module purge
+    module spider intel-oneapi-compilers
+    module load intel-oneapi-compilers/2024.1.0-imjimv2
+    module spider openmpi
+    module load openmpi/5.0.3-65bzfqx
+    module list
+
+Example output from one HPC4 login-node session:
+
+- ``module list`` shows both ``intel-oneapi-compilers/2024.1.0-imjimv2`` and ``openmpi/5.0.3-65bzfqx`` loaded.
+
+.. important::
+
+    On HPC4, this OpenMPI build warns that ``mpirun``/``mpiexec`` should not be treated as the default launcher path.
+    For quick-start job scripts and routine MPI runs, prefer ``srun``.
+
+Clean Environment Reset
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If your shell environment becomes confusing, start from a clean module state.
+
+.. code-block:: bash
+
+    module purge
+    module avail
+
+Spack-Backed Software Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The hkust-hpc documentation shows that some software environments depend on the active Spack instance.
+If your site requires activating a Spack instance before using modules, do that first and then load modules.
+The following sequence is a practical example that worked on one HPC4 account.
+
+.. code-block:: bash
+
+    module purge
+    source /opt/shared/.spack-edge/dist/bin/setup-env.sh -y
+    module avail
+    module spider python
+    module load python/3.12.9-3lxwd5b
+    python --version
+    which python
+    module list
+
+Example output from one HPC4 login-node session:
+
+- ``python --version`` reports ``Python 3.12.9``.
+- ``which python`` points into ``/opt/shared/.spack-edge/.../python-3.12.9-3lxwd5b.../bin/python``.
+- ``module list`` shows ``python/3.12.9-3lxwd5b`` loaded.
+
+For the default login-node environment, prefer the modules already visible in the core tree unless you specifically need software from the edge instance.
+
+.. warning::
+
+   Do not add Spack activation blindly to your shell startup files until you confirm that this is the recommended HPC4 practice for your account and workflow.
+
+Verification Checklist
+----------------------
+
+- Run ``module avail`` successfully.
+- Confirm which software is already visible in the default core tree.
+- If a filtered lookup fails, run ``module spider <name>`` before loading a module.
+- If both commands fail for Python, load ``anaconda3`` or ``miniconda3`` instead.
+- Load one module and verify the related executable is found.
+- If you activate edge Spack, verify ``$SPACK_VARIANT`` and load an explicit module version.
+- For MPI jobs on HPC4, prefer ``srun`` over ``mpirun`` in quick-start workflows.
+- Run ``module list`` to confirm the expected module is active.
+- Use ``module purge`` and confirm the environment resets cleanly.
+
+References
+----------
+
+- :doc:`/software/software-support-overview`
+- :doc:`/software/python/anaconda3`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "sphinx-copybutton~=0.5.2",
     "sphinx-design~=0.6.1",
     "sphinx-rtd-theme~=3.0.2",
+    "sphinxcontrib-mermaid>=2.0.2",
 ]
 license = {text = "MIT"}
 authors = [
@@ -62,6 +63,9 @@ ignore_directives = [
     "grid-item-card",
     "tab-set",
     "tab-item",
+    # Sphinx extension directives (unknown to rstcheck)
+    "graphviz",
+    "mermaid",
     # code-block content validation is skipped: rstcheck produces false
     # positives for Helm templates, bash placeholders (<name>), C headers,
     # and code-block directives without an explicit language specifier.

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -214,6 +214,7 @@ dependencies = [
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-rtd-theme" },
+    { name = "sphinxcontrib-mermaid" },
 ]
 
 [package.dev-dependencies]
@@ -235,6 +236,7 @@ requires-dist = [
     { name = "sphinx-copybutton", specifier = "~=0.5.2" },
     { name = "sphinx-design", specifier = "~=0.6.1" },
     { name = "sphinx-rtd-theme", specifier = "~=3.0.2" },
+    { name = "sphinxcontrib-mermaid", specifier = ">=2.0.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -793,6 +795,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-mermaid"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/3a1cc926da8c563c58ddc124a7b3fe5ccadcae96c96e3a6f8ac3653a210a/sphinxcontrib_mermaid-2.0.2.tar.gz", hash = "sha256:f09576c78ca93fa0e3034fd9c45aaffa7c44ab449de9c43b8b8d262afe52bc66", size = 19265, upload-time = "2026-05-05T13:59:02.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/8d/93be7e0f7fa915a576859b3bfac7a7baa3303181c44d7db7eefbd3e8a69f/sphinxcontrib_mermaid-2.0.2-py3-none-any.whl", hash = "sha256:d862e514991279fb4816302c5cfe167d2557bf3ce7125ae0cb47dac80a0f46ce", size = 14094, upload-time = "2026-05-05T13:59:01.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a new `quick-start` section to provide a simpler onboarding path for first-time HPC4 users.

The new section groups the most common early-user tasks into a short, reader-facing flow:
access, storage, software environment setup, first batch job submission, and follow-up SLURM usage patterns.

## Included pages

- Access and Authentication
- Data and Storage
- Software Environment
- Submit Your First HPC4 Job
- Job Submission

## Validation

- `make build` completed successfully

## Scope

This PR is additive only.
It introduces a new quick-start section and does not rewrite existing software, KB, or compile-guide content.